### PR TITLE
Chepsi/cleanup home screen

### DIFF
--- a/data/src/main/java/com/android254/data/repos/HomeRepoImpl.kt
+++ b/data/src/main/java/com/android254/data/repos/HomeRepoImpl.kt
@@ -39,19 +39,23 @@ class HomeRepoImpl @Inject constructor(
     private val sessionsRepo: SessionsRepo,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : HomeRepo {
-    @RequiresApi(Build.VERSION_CODES.O)
+
     override suspend fun fetchHomeDetails(): HomeDetails {
         return withContext(ioDispatcher) {
             val sponsors = sponsorsApi.fetchSponsors()
             val speakers = speakersRepo.fetchSpeakersUnpacked()
-            val sessions = sessionsRepo.fetchAndSaveSessions()
+            val sessionsResult = sessionsRepo.fetchAndSaveSessions()
+            val sessions = getSessionsFromResourceResult(sessionsResult)
             HomeDetails(
-                isCallForSpeakersEnable = false,
+                isCallForSpeakersEnable = true,
+                linkToCallForSpeakers = "https://t.co/lEQQ9VZQr4",
                 isEventBannerEnable = true,
                 speakers = speakers,
                 speakersCount = speakers.size,
-                sessions = getSessionsFromResourceResult(sessions),
-                sessionsCount = getSessionsFromResourceResult(sessions).size,
+                isSpeakersSessionEnable = speakers.isNotEmpty(),
+                sessions = sessions,
+                sessionsCount = sessions.size,
+                isSessionsSectionEnable = sessions.isNotEmpty(),
                 sponsors = sponsors.getSponsorsList(),
                 organizers = listOf()
             )

--- a/data/src/main/java/com/android254/data/repos/HomeRepoImpl.kt
+++ b/data/src/main/java/com/android254/data/repos/HomeRepoImpl.kt
@@ -15,8 +15,6 @@
  */
 package com.android254.data.repos
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import com.android254.data.di.IoDispatcher
 import com.android254.data.network.apis.SponsorsApi
 import com.android254.data.network.models.responses.SponsorsPagedResponse
@@ -28,10 +26,9 @@ import com.android254.domain.models.Session
 import com.android254.domain.repos.HomeRepo
 import com.android254.domain.repos.SessionsRepo
 import com.android254.domain.repos.SpeakersRepo
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.flow.*
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
 
 class HomeRepoImpl @Inject constructor(
     private val sponsorsApi: SponsorsApi,

--- a/domain/src/main/java/com/android254/domain/models/HomeDetails.kt
+++ b/domain/src/main/java/com/android254/domain/models/HomeDetails.kt
@@ -17,11 +17,14 @@ package com.android254.domain.models
 
 data class HomeDetails(
     val isCallForSpeakersEnable: Boolean,
+    val linkToCallForSpeakers: String,
     val isEventBannerEnable: Boolean,
     val sessions: List<Session>,
     val sessionsCount: Int,
+    val isSessionsSectionEnable: Boolean,
     val speakers: List<Speaker>,
     val speakersCount: Int,
+    val isSpeakersSessionEnable: Boolean,
     val sponsors: List<Sponsors>,
     val organizers: List<OrganizingPartners>
 )

--- a/presentation/src/main/java/com/android254/presentation/home/screen/HomeScreen.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/screen/HomeScreen.kt
@@ -82,18 +82,22 @@ fun HomeScreen(
             HomeHeaderSection()
             HomeBannerSection(homeViewState)
             HomeSpacer()
-            HomeSessionSection(
-                sessions = homeViewState.sessions,
-                onSessionClick = onSessionClicked,
-                onViewAllSessionClicked = navigateToSessionScreen
-            )
-            HomeSpacer()
-            HomeSpeakersSection(
-                speakers = homeViewState.speakers,
-                navigateToSpeakers = navigateToSpeakers,
-                navigateToSpeaker = navigateToSpeaker
-            )
-            HomeSpacer()
+            if (homeViewState.isSessionsSectionVisible){
+                HomeSessionSection(
+                    sessions = homeViewState.sessions,
+                    onSessionClick = onSessionClicked,
+                    onViewAllSessionClicked = navigateToSessionScreen
+                )
+                HomeSpacer()
+            }
+            if (homeViewState.isSpeakersSectionVisible){
+                HomeSpeakersSection(
+                    speakers = homeViewState.speakers,
+                    navigateToSpeakers = navigateToSpeakers,
+                    navigateToSpeaker = navigateToSpeaker
+                )
+                HomeSpacer()
+            }
             SponsorsCard(sponsorsLogos = homeViewState.sponsors)
             HomeSpacer()
         }

--- a/presentation/src/main/java/com/android254/presentation/home/viewmodel/HomeViewModel.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/viewmodel/HomeViewModel.kt
@@ -44,13 +44,14 @@ class HomeViewModel @Inject constructor(
     fun onGetHomeScreenDetails() {
         viewModelScope.launch {
             with(homeRepo.fetchHomeDetails()) {
-                viewState
                 viewState = viewState.copy(
-                    isPosterVisible = this.isEventBannerEnable,
-                    isCallForSpeakersVisible = this.isCallForSpeakersEnable,
-                    linkToCallForSpeakers = "",
+                    isPosterVisible = isEventBannerEnable,
+                    isCallForSpeakersVisible = isCallForSpeakersEnable,
+                    linkToCallForSpeakers = linkToCallForSpeakers,
                     isSignedIn = false,
                     speakers = speakers.toSpeakersPresentation(),
+                    isSpeakersSectionVisible = isSpeakersSessionEnable,
+                    isSessionsSectionVisible = isSessionsSectionEnable,
                     sponsors = sponsors.map { it.sponsorLogoUrl },
                     organizedBy = organizers.map { it.organizerLogoUrl },
                     sessions = sessions.toSessionsPresentation()

--- a/presentation/src/main/java/com/android254/presentation/home/viewmodel/HomeViewModel.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/viewmodel/HomeViewModel.kt
@@ -80,7 +80,7 @@ class HomeViewModel @Inject constructor(
             val hasNoSpeakers = speakers.isEmpty()
 
             SessionPresentationModel(
-                id = it.id.toString(),
+                id = it.id,
                 title = it.title,
                 description = it.description,
                 venue = it.rooms,

--- a/presentation/src/main/java/com/android254/presentation/home/viewstate/HomeViewState.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/viewstate/HomeViewState.kt
@@ -24,7 +24,9 @@ data class HomeViewState(
     val linkToCallForSpeakers: String = "",
     val isSignedIn: Boolean = false,
     val speakers: List<SpeakerUI> = emptyList(),
+    val isSpeakersSectionVisible: Boolean = false,
     val sponsors: List<String> = emptyList(),
     val organizedBy: List<String> = emptyList(),
-    val sessions: List<SessionPresentationModel> = emptyList()
+    val sessions: List<SessionPresentationModel> = emptyList(),
+    val isSessionsSectionVisible: Boolean = false
 )


### PR DESCRIPTION
# Scope
Hides home sections ie. Speakers and Sessions when the list is empty.

_Please make sure to read the [Contribution Guidelines](https://github.com/droidconKE/droidconKE2023Android/blob/main/CONTRIBUTING.md)
and check that you understand and have followed it as best as possible Explain what your feature
does in a short paragraph._ please check the below boxes
- [ ] I have followed the coding conventions
- [ ] I have added/updated necessary tests
- [ ] I have tested the changes added on a physical device
- [ ] I have run `./codeAnalysis.sh` to make sure all lint/formatting checks have been done.

## Closes/Fixes Issues
_Declare any issues by typing `fixes #1` or `closes #1` for example so that the automation can kick
in when this is merged_

## Other testing QA Notes
_What have you tested specifically and what possible impacts/areas there are that may need retesting
by others._

Please add a screenshot (if necessary)
