### PR TITLE
Remove ktlint and detekt plugins in modules

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,6 @@ plugins {
     id("com.google.gms.google-services")
     id("com.google.firebase.crashlytics")
     id("com.google.firebase.firebase-perf")
-    id("org.jlleitschuh.gradle.ktlint")
-    id("io.gitlab.arturbosch.detekt")
 }
 
 android {

--- a/chai/build.gradle.kts
+++ b/chai/build.gradle.kts
@@ -15,10 +15,7 @@
  */
 plugins {
     id("droidconke.android.library")
-    id("org.jetbrains.kotlin.android")
     id("droidconke.android.library.compose")
-    id("org.jlleitschuh.gradle.ktlint")
-    id("io.gitlab.arturbosch.detekt")
 }
 
 android {

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -18,8 +18,6 @@ plugins {
     id("droidconke.android.room")
     id("droidconke.android.hilt")
     kotlin("plugin.serialization")
-    id("org.jlleitschuh.gradle.ktlint")
-    id("io.gitlab.arturbosch.detekt")
 }
 
 android {

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -15,8 +15,6 @@
  */
 plugins {
     id("droidconke.android.library")
-    id("org.jlleitschuh.gradle.ktlint")
-    id("io.gitlab.arturbosch.detekt")
 }
 
 android {

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -17,8 +17,6 @@ plugins {
     id("droidconke.android.library")
     id("droidconke.android.hilt")
     id("droidconke.android.library.compose")
-    id("org.jlleitschuh.gradle.ktlint")
-    id("io.gitlab.arturbosch.detekt")
 }
 
 android {


### PR DESCRIPTION
# Scope
Ktlint and Detekt plugins have been applied on the project level `build.gradle.kts` as all project and sub projects plugins respectively. 

Applying a plugin on the all projects implementation applies the plugin to the whole project and its sub projects(modules), this means that Klint plugin has already been applied hence applying on the module is just a duplicate.

Applying a plugin on sub projects implementation applies the plugin in all the project sub projects(modules), this means that Detekt plugin has already been applied hence applying on the module is just a duplicate .

_Please make sure to read the [Contribution Guidelines](https://github.com/droidconKE/droidconKE2023Android/blob/main/CONTRIBUTING.md)
and check that you understand and have followed it as best as possible Explain what your feature
does in a short paragraph._ please check the below boxes
- [x] I have followed the coding conventions
- [x] I have added/updated necessary tests
- [x] I have tested the changes added on a physical device
- [x] I have run `./codeAnalysis.sh` on linux/unix or `codeAnalysys.bat` on windows to make sure all lint/formatting checks have been done.

## Closes/Fixes Issues
N/A

## Other testing QA Notes

**Option 1** - Run the ktlint and detekt tasks to make sure it runs in all the modules
**Option 2** - Run a gradle build scan then check on the plugins sections and confirm that the plugins have been applied to all modules.

Please add a screenshot (if necessary)

Screenshots from gradle build scan:
<img width="1044" alt="Screenshot 2023-07-30 at 17 44 32" src="https://github.com/droidconKE/droidconKE2023Android/assets/61080898/8098878c-26a7-499f-b98e-2738d0c3df5e">
<img width="1044" alt="Screenshot 2023-07-30 at 17 44 42" src="https://github.com/droidconKE/droidconKE2023Android/assets/61080898/e22aee97-3130-49c9-b192-e95335df8881">

N/A