### PR TITLE
Fix Feed Endpoint

### DIFF
--- a/data/src/main/java/com/android254/data/network/apis/FeedApi.kt
+++ b/data/src/main/java/com/android254/data/network/apis/FeedApi.kt
@@ -18,17 +18,17 @@ package com.android254.data.network.apis
 import com.android254.data.network.models.responses.FeedDTO
 import com.android254.data.network.models.responses.PaginatedResponse
 import com.android254.data.network.util.dataResultSafeApiCall
-import com.android254.data.network.util.provideBaseUrl
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.request.get
+import com.android254.data.network.util.provideEventBaseUrl
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
 import javax.inject.Inject
 
 class FeedApi @Inject constructor(private val client: HttpClient) {
 
     suspend fun fetchFeed(page: Int = 1, size: Int = 100) = dataResultSafeApiCall {
         val response: PaginatedResponse<List<FeedDTO>> =
-            client.get("${provideBaseUrl()}/feeds") {
+            client.get("${provideEventBaseUrl()}/feeds") {
                 url {
                     parameters.append("page", page.toString())
                     parameters.append("per_page", size.toString())

--- a/data/src/test/java/com/android254/data/network/apis/FeedApiTest.kt
+++ b/data/src/test/java/com/android254/data/network/apis/FeedApiTest.kt
@@ -19,23 +19,19 @@ import com.android254.data.network.models.responses.FeedDTO
 import com.android254.data.network.util.HttpClientFactory
 import com.android254.data.network.util.MockTokenProvider
 import com.android254.data.network.util.RemoteFeatureToggle
-import com.android254.data.network.util.provideBaseUrl
+import com.android254.data.network.util.provideEventBaseUrl
 import com.android254.domain.models.DataResult
-import io.ktor.client.engine.mock.MockEngine
-import io.ktor.client.engine.mock.respond
-import io.ktor.client.engine.mock.respondOk
-import io.ktor.http.HttpHeaders
-import io.ktor.http.HttpMethod
-import io.ktor.http.headersOf
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
 import io.mockk.mockk
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
 import kotlinx.coroutines.test.runTest
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
 import org.junit.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
 
 class FeedApiTest {
 
@@ -55,7 +51,7 @@ class FeedApiTest {
 
         assertThat(mockEngine.requestHistory.size, `is`(1))
         mockEngine.requestHistory.first().run {
-            val expectedUrl = "${provideBaseUrl()}/feeds?page=2&per_page=50"
+            val expectedUrl = "${provideEventBaseUrl()}/feeds?page=2&per_page=50"
             assertThat(url.toString(), `is`(expectedUrl))
             assertThat(method, `is`(HttpMethod.Get))
         }

--- a/data/src/test/java/com/android254/data/repos/SessionsManagerTest.kt
+++ b/data/src/test/java/com/android254/data/repos/SessionsManagerTest.kt
@@ -19,10 +19,8 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android254.data.dao.BookmarkDao
-import com.android254.data.dao.SessionDao
 import com.android254.data.db.Database
 import com.android254.data.db.model.SessionEntity
-import com.android254.data.network.apis.SessionsApi
 import com.android254.data.repos.local.LocalSessionsDataSource
 import com.android254.data.repos.mappers.toDomainModel
 import com.android254.data.repos.remote.RemoteSessionsDataSource
@@ -61,11 +59,11 @@ class SessionsManagerTest {
 
     @Test
     fun `test it fetches from the local cache`() = runTest {
-       coEvery { mockLocalSessionsDataSource.getCachedSessions() } returns
-               flowOf(listOf(sessionEntity.toDomainModel()))
+        coEvery { mockLocalSessionsDataSource.getCachedSessions() } returns
+            flowOf(listOf(sessionEntity.toDomainModel()))
         val sessions = mockLocalSessionsDataSource.getCachedSessions().first()
         assert(sessions[0].description == sessionEntity.description)
-        coVerify (atLeast = 1){
+        coVerify(atLeast = 1) {
             mockLocalSessionsDataSource.getCachedSessions()
         }
     }

--- a/presentation/src/main/java/com/android254/presentation/about/view/AboutScreen.kt
+++ b/presentation/src/main/java/com/android254/presentation/about/view/AboutScreen.kt
@@ -15,9 +15,8 @@
  */
 package com.android254.presentation.about.view
 
-
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -34,7 +33,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale

--- a/presentation/src/test/java/com/android254/presentation/feed/view/FeedScreenTest.kt
+++ b/presentation/src/test/java/com/android254/presentation/feed/view/FeedScreenTest.kt
@@ -51,7 +51,18 @@ class FeedScreenTest {
 
     @Test
     fun `should display feed items`() {
-        coEvery { repo.fetchFeed() } returns ResourceResult.Success(listOf(Feed("", "", "", "", "", "")))
+        coEvery { repo.fetchFeed() } returns ResourceResult.Success(
+            listOf(
+                Feed(
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    ""
+                )
+            )
+        )
 
         composeTestRule.setContent {
             DroidconKE2023Theme {
@@ -68,7 +79,18 @@ class FeedScreenTest {
 
     @Test
     fun `test share bottom sheet is shown`() {
-        coEvery { repo.fetchFeed() } returns ResourceResult.Success(listOf(Feed("", "", "", "", "", "")))
+        coEvery { repo.fetchFeed() } returns ResourceResult.Success(
+            listOf(
+                Feed(
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    ""
+                )
+            )
+        )
 
         composeTestRule.setContent {
             DroidconKE2023Theme {


### PR DESCRIPTION
# Scope
This PR fixes the feed endpoint path. We can now be able to fetch the Feeds


_Please make sure to read the [Contribution Guidelines](https://github.com/droidconKE/droidconKE2023Android/blob/main/CONTRIBUTING.md)
and check that you understand and have followed it as best as possible Explain what your feature
does in a short paragraph._ please check the below boxes
- [ ] I have followed the coding conventions
- [ ] I have added/updated necessary tests
- [ ] I have tested the changes added on a physical device
- [ ] I have run `./codeAnalysis.sh` on linux/unix or `codeAnalysys.bat` on windows to make sure all lint/formatting checks have been done.

## Closes/Fixes Issues
_Declare any issues by typing `fixes #1` or `closes #1` for example so that the automation can kick
in when this is merged_

## Other testing QA Notes
_What have you tested specifically and what possible impacts/areas there are that may need retesting
by others._


Please add a screenshot (if necessary)
![Screenshot 2023-09-08 at 17 48 42](https://github.com/droidconKE/droidconKE2023Android/assets/15122455/45f2c51e-f587-42e3-8b14-c3303d78a0e6)

