### PR TITLE
feat: edge-to-edge insets, and clear the remaining Compose lint debt

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -9,8 +9,6 @@
         <item name="colorSecondary">@color/teal_200</item>
         <item name="colorSecondaryVariant">@color/teal_200</item>
         <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -9,8 +9,6 @@
         <item name="colorSecondary">@color/teal_200</item>
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
     </style>
 </resources>

--- a/chai/src/main/java/com/droidconke/chai/Theme.kt
+++ b/chai/src/main/java/com/droidconke/chai/Theme.kt
@@ -15,18 +15,11 @@
  */
 package com.droidconke.chai
 
-import android.app.Activity
-import android.content.Context
-import android.content.ContextWrapper
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
-import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalView
-import androidx.core.view.WindowCompat
 import com.droidconke.chai.colors.ChaiColors
 import com.droidconke.chai.colors.ChaiDarkColorPalette
 import com.droidconke.chai.colors.ChaiLightColorPalette
@@ -37,17 +30,7 @@ fun ChaiTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit,
 ) {
-    val view = LocalView.current
     val customColorsPalette = if (darkTheme) ChaiDarkColorPalette else ChaiLightColorPalette
-
-    if (!view.isInEditMode) {
-        SideEffect {
-            val window = view.context.findActivity()?.window ?: return@SideEffect
-            @Suppress("DEPRECATION")
-            window.statusBarColor = customColorsPalette.background.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
-        }
-    }
 
     CompositionLocalProvider(
         LocalChaiColorsPalette provides customColorsPalette,
@@ -62,15 +45,3 @@ val MaterialTheme.chaiColorsPalette: ChaiColors
     @Composable
     @ReadOnlyComposable
     get() = LocalChaiColorsPalette.current
-
-/**
- * The closest [Activity], or null when the composition is not hosted by one — Robolectric,
- * screenshot tests, a `ComposeView` outside an Activity. Never throws: a theme must not be
- * able to crash those.
- */
-private tailrec fun Context.findActivity(): Activity? =
-    when (this) {
-        is Activity -> this
-        is ContextWrapper -> baseContext.findActivity()
-        else -> null
-    }

--- a/chai/src/main/java/com/droidconke/chai/components/CButtons.kt
+++ b/chai/src/main/java/com/droidconke/chai/components/CButtons.kt
@@ -40,10 +40,10 @@ import com.droidconke.chai.utils.SeparatorSpace
 @Composable
 fun CButton(
     onClick: () -> Unit,
-    modifier: Modifier = Modifier,
     isEnabled: Boolean,
     colors: ButtonColors,
     shape: Shape,
+    modifier: Modifier = Modifier,
     content: @Composable RowScope.() -> Unit,
 ) {
     Button(
@@ -59,9 +59,9 @@ fun CButton(
 @Composable
 fun COutlinedButton(
     onClick: () -> Unit,
-    modifier: Modifier = Modifier,
     colors: ButtonColors,
     shape: Shape,
+    modifier: Modifier = Modifier,
     content: @Composable RowScope.() -> Unit,
 ) {
     OutlinedButton(
@@ -76,9 +76,9 @@ fun COutlinedButton(
 @Composable
 fun CPrimaryButton(
     onClick: () -> Unit,
-    modifier: Modifier = Modifier,
     isEnabled: Boolean,
     title: String,
+    modifier: Modifier = Modifier,
 ) {
     CButton(
         onClick = onClick,
@@ -99,9 +99,9 @@ fun CPrimaryButton(
 @Composable
 fun COutlinedPrimaryButton(
     onClick: () -> Unit,
-    modifier: Modifier = Modifier,
     title: String,
     icon: ImageVector,
+    modifier: Modifier = Modifier,
 ) {
     COutlinedButton(
         onClick = onClick,

--- a/chai/src/main/java/com/droidconke/chai/components/CButtons.kt
+++ b/chai/src/main/java/com/droidconke/chai/components/CButtons.kt
@@ -120,7 +120,7 @@ private const val PREVIEW_OUTLINE_BUTTON_TITLE = "Twitter"
 
 @Preview
 @Composable
-fun CPrimaryButtonDarkPreview() {
+private fun CPrimaryButtonDarkPreview() {
     ChaiTheme(darkTheme = true) {
         CPrimaryButton(
             onClick = { },
@@ -133,7 +133,7 @@ fun CPrimaryButtonDarkPreview() {
 
 @Preview
 @Composable
-fun CPrimaryButtonDisableDarkPreview() {
+private fun CPrimaryButtonDisableDarkPreview() {
     ChaiTheme(darkTheme = true) {
         CPrimaryButton(
             onClick = { },
@@ -146,7 +146,7 @@ fun CPrimaryButtonDisableDarkPreview() {
 
 @Preview
 @Composable
-fun CPrimaryButtonDisableLightPreview() {
+private fun CPrimaryButtonDisableLightPreview() {
     ChaiTheme(darkTheme = false) {
         CPrimaryButton(
             onClick = { },
@@ -159,7 +159,7 @@ fun CPrimaryButtonDisableLightPreview() {
 
 @Preview
 @Composable
-fun CPrimaryButtonLightPreview() {
+private fun CPrimaryButtonLightPreview() {
     ChaiTheme {
         CPrimaryButton(
             onClick = { },
@@ -172,7 +172,7 @@ fun CPrimaryButtonLightPreview() {
 
 @Preview
 @Composable
-fun CPrimaryOutlinedButtonLightPreview() {
+private fun CPrimaryOutlinedButtonLightPreview() {
     ChaiTheme(darkTheme = false) {
         COutlinedPrimaryButton(
             onClick = { },
@@ -185,7 +185,7 @@ fun CPrimaryOutlinedButtonLightPreview() {
 
 @Preview
 @Composable
-fun CPrimaryOutlinedButtonDarktPreview() {
+private fun CPrimaryOutlinedButtonDarktPreview() {
     ChaiTheme(darkTheme = true) {
         COutlinedPrimaryButton(
             onClick = { },

--- a/chai/src/main/java/com/droidconke/chai/components/CText.kt
+++ b/chai/src/main/java/com/droidconke/chai/components/CText.kt
@@ -47,8 +47,8 @@ import com.droidconke.chai.chaiColorsPalette
 
 @Composable
 fun ChaiTitle(
-    modifier: Modifier = Modifier,
     titleText: String,
+    modifier: Modifier = Modifier,
     titleColor: Color = Color.Unspecified,
 ) {
     Text(
@@ -67,8 +67,8 @@ fun ChaiTitle(
 
 @Composable
 fun ChaiSubTitle(
-    modifier: Modifier = Modifier,
     titleText: String,
+    modifier: Modifier = Modifier,
     titleColor: Color = Color.Unspecified,
     textAlign: TextAlign? = TextAlign.Start,
 ) {
@@ -89,8 +89,8 @@ fun ChaiSubTitle(
 
 @Composable
 fun ChaiBodyXSmallBold(
-    modifier: Modifier = Modifier,
     bodyText: String,
+    modifier: Modifier = Modifier,
     textColor: Color = Color.Unspecified,
     textAlign: TextAlign? = TextAlign.Start,
 ) {
@@ -111,8 +111,8 @@ fun ChaiBodyXSmallBold(
 
 @Composable
 fun ChaiBodyXSmall(
-    modifier: Modifier = Modifier,
     bodyText: String,
+    modifier: Modifier = Modifier,
     textColor: Color = Color.Unspecified,
 ) {
     Text(
@@ -132,8 +132,8 @@ fun ChaiBodyXSmall(
 
 @Composable
 fun ChaiBodySmallBold(
-    modifier: Modifier = Modifier,
     bodyText: String,
+    modifier: Modifier = Modifier,
     textColor: Color = Color.Unspecified,
     maxLines: Int = Int.MAX_VALUE,
 ) {
@@ -155,8 +155,8 @@ fun ChaiBodySmallBold(
 
 @Composable
 fun ChaiBodySmall(
-    modifier: Modifier = Modifier,
     bodyText: String,
+    modifier: Modifier = Modifier,
     textColor: Color = Color.Unspecified,
     textAlign: TextAlign = TextAlign.Start,
     maxLines: Int = Int.MAX_VALUE,
@@ -182,8 +182,8 @@ fun ChaiBodySmall(
 
 @Composable
 fun ChaiBodyMediumBold(
-    modifier: Modifier = Modifier,
     bodyText: String,
+    modifier: Modifier = Modifier,
     textColor: Color = Color.Unspecified,
     textAlign: TextAlign = TextAlign.Start,
     maxLines: Int = Int.MAX_VALUE,
@@ -207,8 +207,8 @@ fun ChaiBodyMediumBold(
 
 @Composable
 fun ChaiBodyMedium(
-    modifier: Modifier = Modifier,
     bodyText: String,
+    modifier: Modifier = Modifier,
     textColor: Color = Color.Unspecified,
     maxLines: Int = Int.MAX_VALUE,
 ) {
@@ -231,8 +231,8 @@ fun ChaiBodyMedium(
 
 @Composable
 fun ChaiBodyLargeBold(
-    modifier: Modifier = Modifier,
     bodyText: String,
+    modifier: Modifier = Modifier,
     textColor: Color = Color.Unspecified,
     maxLines: Int = Int.MAX_VALUE,
     overflow: TextOverflow = TextOverflow.Ellipsis,
@@ -256,8 +256,8 @@ fun ChaiBodyLargeBold(
 
 @Composable
 fun ChaiBodyLarge(
-    modifier: Modifier = Modifier,
     bodyText: String,
+    modifier: Modifier = Modifier,
     textColor: Color = Color.Unspecified,
 ) {
     Text(
@@ -277,8 +277,8 @@ fun ChaiBodyLarge(
 
 @Composable
 fun ChaiTextButtonLight(
-    modifier: Modifier = Modifier,
     bodyText: String,
+    modifier: Modifier = Modifier,
     textColor: Color = Color.Unspecified,
 ) {
     Text(
@@ -298,8 +298,8 @@ fun ChaiTextButtonLight(
 
 @Composable
 fun CPrimaryButtonText(
-    modifier: Modifier = Modifier,
     text: String,
+    modifier: Modifier = Modifier,
     textAllCaps: Boolean = false,
     textColor: Color = MaterialTheme.chaiColorsPalette.textButtonColor,
 ) {
@@ -320,8 +320,8 @@ fun CPrimaryButtonText(
 
 @Composable
 fun ChaiTextLabelLarge(
-    modifier: Modifier = Modifier,
     bodyText: String,
+    modifier: Modifier = Modifier,
     textColor: Color = Color.Unspecified,
     textAlign: TextAlign = TextAlign.Start,
 ) {
@@ -342,8 +342,8 @@ fun ChaiTextLabelLarge(
 
 @Composable
 fun ChaiTextLabelMedium(
-    modifier: Modifier = Modifier,
     bodyText: String,
+    modifier: Modifier = Modifier,
     textColor: Color = Color.Unspecified,
 ) {
     Text(
@@ -363,8 +363,8 @@ fun ChaiTextLabelMedium(
 
 @Composable
 fun ChaiTextLabelSmall(
-    modifier: Modifier = Modifier,
     bodyText: String,
+    modifier: Modifier = Modifier,
     textColor: Color = Color.Unspecified,
 ) {
     Text(

--- a/chai/src/main/java/com/droidconke/chai/components/CText.kt
+++ b/chai/src/main/java/com/droidconke/chai/components/CText.kt
@@ -114,6 +114,7 @@ fun ChaiBodyXSmall(
     bodyText: String,
     modifier: Modifier = Modifier,
     textColor: Color = Color.Unspecified,
+    maxLines: Int = Int.MAX_VALUE,
 ) {
     Text(
         modifier = modifier,
@@ -127,6 +128,8 @@ fun ChaiBodyXSmall(
                 lineHeight = 16.sp,
             ),
         textAlign = TextAlign.Start,
+        maxLines = maxLines,
+        overflow = TextOverflow.Ellipsis,
     )
 }
 

--- a/chai/src/main/java/com/droidconke/chai/utils/Spacing.kt
+++ b/chai/src/main/java/com/droidconke/chai/utils/Spacing.kt
@@ -21,16 +21,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun BreathingSpace13() {
-    Spacer(modifier = Modifier.height(15.dp))
+fun BreathingSpace13(modifier: Modifier = Modifier) {
+    Spacer(modifier = modifier.height(15.dp))
 }
 
 @Composable
-fun BreathingSpace26() {
-    Spacer(modifier = Modifier.height(26.dp))
+fun BreathingSpace26(modifier: Modifier = Modifier) {
+    Spacer(modifier = modifier.height(26.dp))
 }
 
 @Composable
-fun SeparatorSpace() {
-    Spacer(modifier = Modifier.height(5.dp))
+fun SeparatorSpace(modifier: Modifier = Modifier) {
+    Spacer(modifier = modifier.height(5.dp))
 }

--- a/chai/stability/chai-debug.stability
+++ b/chai/stability/chai-debug.stability
@@ -142,13 +142,14 @@ public fun com.droidconke.chai.components.ChaiBodySmallBold(bodyText: kotlin.Str
     - maxLines: STABLE (primitive type)
 
 @Composable
-public fun com.droidconke.chai.components.ChaiBodyXSmall(bodyText: kotlin.String, modifier: androidx.compose.ui.Modifier, textColor: androidx.compose.ui.graphics.Color): kotlin.Unit
+public fun com.droidconke.chai.components.ChaiBodyXSmall(bodyText: kotlin.String, modifier: androidx.compose.ui.Modifier, textColor: androidx.compose.ui.graphics.Color, maxLines: kotlin.Int): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - bodyText: STABLE (String is immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
     - textColor: STABLE (marked @Stable or @Immutable)
+    - maxLines: STABLE (primitive type)
 
 @Composable
 public fun com.droidconke.chai.components.ChaiBodyXSmallBold(bodyText: kotlin.String, modifier: androidx.compose.ui.Modifier, textColor: androidx.compose.ui.graphics.Color, textAlign: androidx.compose.ui.text.style.TextAlign?): kotlin.Unit

--- a/chai/stability/chai-debug.stability
+++ b/chai/stability/chai-debug.stability
@@ -26,137 +26,137 @@ public fun com.droidconke.chai.colors.venueAccentColor(venue: kotlin.String): an
     - venue: STABLE (String is immutable)
 
 @Composable
-public fun com.droidconke.chai.components.CButton(onClick: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier, isEnabled: kotlin.Boolean, colors: androidx.compose.material3.ButtonColors, shape: androidx.compose.ui.graphics.Shape, content: @[Composable] @[ExtensionFunctionType] androidx.compose.runtime.internal.ComposableFunction1<androidx.compose.foundation.layout.RowScope, kotlin.Unit>): kotlin.Unit
+public fun com.droidconke.chai.components.CButton(onClick: kotlin.Function0<kotlin.Unit>, isEnabled: kotlin.Boolean, colors: androidx.compose.material3.ButtonColors, shape: androidx.compose.ui.graphics.Shape, modifier: androidx.compose.ui.Modifier, content: @[Composable] @[ExtensionFunctionType] androidx.compose.runtime.internal.ComposableFunction1<androidx.compose.foundation.layout.RowScope, kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - onClick: STABLE (function type)
-    - modifier: STABLE (marked @Stable or @Immutable)
     - isEnabled: STABLE (primitive type)
     - colors: STABLE (marked @Stable or @Immutable)
     - shape: STABLE (marked @Stable or @Immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - content: STABLE (composable function type)
 
 @Composable
-public fun com.droidconke.chai.components.COutlinedButton(onClick: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier, colors: androidx.compose.material3.ButtonColors, shape: androidx.compose.ui.graphics.Shape, content: @[Composable] @[ExtensionFunctionType] androidx.compose.runtime.internal.ComposableFunction1<androidx.compose.foundation.layout.RowScope, kotlin.Unit>): kotlin.Unit
+public fun com.droidconke.chai.components.COutlinedButton(onClick: kotlin.Function0<kotlin.Unit>, colors: androidx.compose.material3.ButtonColors, shape: androidx.compose.ui.graphics.Shape, modifier: androidx.compose.ui.Modifier, content: @[Composable] @[ExtensionFunctionType] androidx.compose.runtime.internal.ComposableFunction1<androidx.compose.foundation.layout.RowScope, kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - onClick: STABLE (function type)
-    - modifier: STABLE (marked @Stable or @Immutable)
     - colors: STABLE (marked @Stable or @Immutable)
     - shape: STABLE (marked @Stable or @Immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - content: STABLE (composable function type)
 
 @Composable
-public fun com.droidconke.chai.components.COutlinedPrimaryButton(onClick: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier, title: kotlin.String, icon: androidx.compose.ui.graphics.vector.ImageVector): kotlin.Unit
+public fun com.droidconke.chai.components.COutlinedPrimaryButton(onClick: kotlin.Function0<kotlin.Unit>, title: kotlin.String, icon: androidx.compose.ui.graphics.vector.ImageVector, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - onClick: STABLE (function type)
-    - modifier: STABLE (marked @Stable or @Immutable)
     - title: STABLE (String is immutable)
     - icon: STABLE (marked @Stable or @Immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.droidconke.chai.components.CPrimaryButton(onClick: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier, isEnabled: kotlin.Boolean, title: kotlin.String): kotlin.Unit
+public fun com.droidconke.chai.components.CPrimaryButton(onClick: kotlin.Function0<kotlin.Unit>, isEnabled: kotlin.Boolean, title: kotlin.String, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - onClick: STABLE (function type)
-    - modifier: STABLE (marked @Stable or @Immutable)
     - isEnabled: STABLE (primitive type)
     - title: STABLE (String is immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.droidconke.chai.components.CPrimaryButtonText(modifier: androidx.compose.ui.Modifier, text: kotlin.String, textAllCaps: kotlin.Boolean, textColor: androidx.compose.ui.graphics.Color): kotlin.Unit
+public fun com.droidconke.chai.components.CPrimaryButtonText(text: kotlin.String, modifier: androidx.compose.ui.Modifier, textAllCaps: kotlin.Boolean, textColor: androidx.compose.ui.graphics.Color): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - text: STABLE (String is immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - textAllCaps: STABLE (primitive type)
     - textColor: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.droidconke.chai.components.ChaiBodyLarge(modifier: androidx.compose.ui.Modifier, bodyText: kotlin.String, textColor: androidx.compose.ui.graphics.Color): kotlin.Unit
+public fun com.droidconke.chai.components.ChaiBodyLarge(bodyText: kotlin.String, modifier: androidx.compose.ui.Modifier, textColor: androidx.compose.ui.graphics.Color): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - bodyText: STABLE (String is immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - textColor: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.droidconke.chai.components.ChaiBodyLargeBold(modifier: androidx.compose.ui.Modifier, bodyText: kotlin.String, textColor: androidx.compose.ui.graphics.Color, maxLines: kotlin.Int, overflow: androidx.compose.ui.text.style.TextOverflow): kotlin.Unit
+public fun com.droidconke.chai.components.ChaiBodyLargeBold(bodyText: kotlin.String, modifier: androidx.compose.ui.Modifier, textColor: androidx.compose.ui.graphics.Color, maxLines: kotlin.Int, overflow: androidx.compose.ui.text.style.TextOverflow): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - bodyText: STABLE (String is immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - textColor: STABLE (marked @Stable or @Immutable)
     - maxLines: STABLE (primitive type)
     - overflow: STABLE (known stable type)
 
 @Composable
-public fun com.droidconke.chai.components.ChaiBodyMedium(modifier: androidx.compose.ui.Modifier, bodyText: kotlin.String, textColor: androidx.compose.ui.graphics.Color, maxLines: kotlin.Int): kotlin.Unit
+public fun com.droidconke.chai.components.ChaiBodyMedium(bodyText: kotlin.String, modifier: androidx.compose.ui.Modifier, textColor: androidx.compose.ui.graphics.Color, maxLines: kotlin.Int): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - bodyText: STABLE (String is immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - textColor: STABLE (marked @Stable or @Immutable)
     - maxLines: STABLE (primitive type)
 
 @Composable
-public fun com.droidconke.chai.components.ChaiBodyMediumBold(modifier: androidx.compose.ui.Modifier, bodyText: kotlin.String, textColor: androidx.compose.ui.graphics.Color, textAlign: androidx.compose.ui.text.style.TextAlign, maxLines: kotlin.Int): kotlin.Unit
+public fun com.droidconke.chai.components.ChaiBodyMediumBold(bodyText: kotlin.String, modifier: androidx.compose.ui.Modifier, textColor: androidx.compose.ui.graphics.Color, textAlign: androidx.compose.ui.text.style.TextAlign, maxLines: kotlin.Int): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - bodyText: STABLE (String is immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - textColor: STABLE (marked @Stable or @Immutable)
     - textAlign: STABLE (known stable type)
     - maxLines: STABLE (primitive type)
 
 @Composable
-public fun com.droidconke.chai.components.ChaiBodySmall(modifier: androidx.compose.ui.Modifier, bodyText: kotlin.String, textColor: androidx.compose.ui.graphics.Color, textAlign: androidx.compose.ui.text.style.TextAlign, maxLines: kotlin.Int, minLines: kotlin.Int): kotlin.Unit
+public fun com.droidconke.chai.components.ChaiBodySmall(bodyText: kotlin.String, modifier: androidx.compose.ui.Modifier, textColor: androidx.compose.ui.graphics.Color, textAlign: androidx.compose.ui.text.style.TextAlign, maxLines: kotlin.Int, minLines: kotlin.Int): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - bodyText: STABLE (String is immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - textColor: STABLE (marked @Stable or @Immutable)
     - textAlign: STABLE (known stable type)
     - maxLines: STABLE (primitive type)
     - minLines: STABLE (primitive type)
 
 @Composable
-public fun com.droidconke.chai.components.ChaiBodySmallBold(modifier: androidx.compose.ui.Modifier, bodyText: kotlin.String, textColor: androidx.compose.ui.graphics.Color, maxLines: kotlin.Int): kotlin.Unit
+public fun com.droidconke.chai.components.ChaiBodySmallBold(bodyText: kotlin.String, modifier: androidx.compose.ui.Modifier, textColor: androidx.compose.ui.graphics.Color, maxLines: kotlin.Int): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - bodyText: STABLE (String is immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - textColor: STABLE (marked @Stable or @Immutable)
     - maxLines: STABLE (primitive type)
 
 @Composable
-public fun com.droidconke.chai.components.ChaiBodyXSmall(modifier: androidx.compose.ui.Modifier, bodyText: kotlin.String, textColor: androidx.compose.ui.graphics.Color): kotlin.Unit
+public fun com.droidconke.chai.components.ChaiBodyXSmall(bodyText: kotlin.String, modifier: androidx.compose.ui.Modifier, textColor: androidx.compose.ui.graphics.Color): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - bodyText: STABLE (String is immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - textColor: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.droidconke.chai.components.ChaiBodyXSmallBold(modifier: androidx.compose.ui.Modifier, bodyText: kotlin.String, textColor: androidx.compose.ui.graphics.Color, textAlign: androidx.compose.ui.text.style.TextAlign?): kotlin.Unit
+public fun com.droidconke.chai.components.ChaiBodyXSmallBold(bodyText: kotlin.String, modifier: androidx.compose.ui.Modifier, textColor: androidx.compose.ui.graphics.Color, textAlign: androidx.compose.ui.text.style.TextAlign?): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - bodyText: STABLE (String is immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - textColor: STABLE (marked @Stable or @Immutable)
     - textAlign: STABLE (known stable type)
 
@@ -172,76 +172,79 @@ public fun com.droidconke.chai.components.ChaiPullToRefreshBox(isRefreshing: kot
     - content: STABLE (composable function type)
 
 @Composable
-public fun com.droidconke.chai.components.ChaiSubTitle(modifier: androidx.compose.ui.Modifier, titleText: kotlin.String, titleColor: androidx.compose.ui.graphics.Color, textAlign: androidx.compose.ui.text.style.TextAlign?): kotlin.Unit
+public fun com.droidconke.chai.components.ChaiSubTitle(titleText: kotlin.String, modifier: androidx.compose.ui.Modifier, titleColor: androidx.compose.ui.graphics.Color, textAlign: androidx.compose.ui.text.style.TextAlign?): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - titleText: STABLE (String is immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - titleColor: STABLE (marked @Stable or @Immutable)
     - textAlign: STABLE (known stable type)
 
 @Composable
-public fun com.droidconke.chai.components.ChaiTextButtonLight(modifier: androidx.compose.ui.Modifier, bodyText: kotlin.String, textColor: androidx.compose.ui.graphics.Color): kotlin.Unit
+public fun com.droidconke.chai.components.ChaiTextButtonLight(bodyText: kotlin.String, modifier: androidx.compose.ui.Modifier, textColor: androidx.compose.ui.graphics.Color): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - bodyText: STABLE (String is immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - textColor: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.droidconke.chai.components.ChaiTextLabelLarge(modifier: androidx.compose.ui.Modifier, bodyText: kotlin.String, textColor: androidx.compose.ui.graphics.Color, textAlign: androidx.compose.ui.text.style.TextAlign): kotlin.Unit
+public fun com.droidconke.chai.components.ChaiTextLabelLarge(bodyText: kotlin.String, modifier: androidx.compose.ui.Modifier, textColor: androidx.compose.ui.graphics.Color, textAlign: androidx.compose.ui.text.style.TextAlign): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - bodyText: STABLE (String is immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - textColor: STABLE (marked @Stable or @Immutable)
     - textAlign: STABLE (known stable type)
 
 @Composable
-public fun com.droidconke.chai.components.ChaiTextLabelMedium(modifier: androidx.compose.ui.Modifier, bodyText: kotlin.String, textColor: androidx.compose.ui.graphics.Color): kotlin.Unit
+public fun com.droidconke.chai.components.ChaiTextLabelMedium(bodyText: kotlin.String, modifier: androidx.compose.ui.Modifier, textColor: androidx.compose.ui.graphics.Color): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - bodyText: STABLE (String is immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - textColor: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.droidconke.chai.components.ChaiTextLabelSmall(modifier: androidx.compose.ui.Modifier, bodyText: kotlin.String, textColor: androidx.compose.ui.graphics.Color): kotlin.Unit
+public fun com.droidconke.chai.components.ChaiTextLabelSmall(bodyText: kotlin.String, modifier: androidx.compose.ui.Modifier, textColor: androidx.compose.ui.graphics.Color): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - bodyText: STABLE (String is immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - textColor: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.droidconke.chai.components.ChaiTitle(modifier: androidx.compose.ui.Modifier, titleText: kotlin.String, titleColor: androidx.compose.ui.graphics.Color): kotlin.Unit
+public fun com.droidconke.chai.components.ChaiTitle(titleText: kotlin.String, modifier: androidx.compose.ui.Modifier, titleColor: androidx.compose.ui.graphics.Color): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - titleText: STABLE (String is immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - titleColor: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.droidconke.chai.utils.BreathingSpace13(): kotlin.Unit
+public fun com.droidconke.chai.utils.BreathingSpace13(modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.droidconke.chai.utils.BreathingSpace26(): kotlin.Unit
+public fun com.droidconke.chai.utils.BreathingSpace26(modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.droidconke.chai.utils.SeparatorSpace(): kotlin.Unit
+public fun com.droidconke.chai.utils.SeparatorSpace(modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
+    - modifier: STABLE (marked @Stable or @Immutable)
 

--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -34,6 +34,7 @@
     <issue id="ComposeViewModelInjection" severity="error" />
     <issue id="ComposePreviewNaming" severity="error" />
     <issue id="ComposeRedundantComposable" severity="error" />
+    <issue id="ComposePreviewPublic" severity="error" />
 
     <issue id="ComposeCompositionLocalUsage" severity="error">
         <ignore regexp="chai/colors/ChaiColors\.kt" />
@@ -43,7 +44,6 @@
     <issue id="ComposeModifierMissing" severity="warning" />
     <issue id="ComposeParameterOrder" severity="warning" />
     <issue id="ComposeUnstableCollections" severity="warning" />
-    <issue id="ComposePreviewPublic" severity="warning" />
 
     <issue id="GradleDependency" severity="informational" />
     <issue id="AndroidGradlePluginVersion" severity="informational" />

--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -35,6 +35,7 @@
     <issue id="ComposePreviewNaming" severity="error" />
     <issue id="ComposeRedundantComposable" severity="error" />
     <issue id="ComposePreviewPublic" severity="error" />
+    <issue id="ComposeUnstableCollections" severity="error" />
 
     <issue id="ComposeCompositionLocalUsage" severity="error">
         <ignore regexp="chai/colors/ChaiColors\.kt" />
@@ -43,7 +44,6 @@
 
     <issue id="ComposeModifierMissing" severity="warning" />
     <issue id="ComposeParameterOrder" severity="warning" />
-    <issue id="ComposeUnstableCollections" severity="warning" />
 
     <issue id="GradleDependency" severity="informational" />
     <issue id="AndroidGradlePluginVersion" severity="informational" />

--- a/data/src/main/java/com/android254/data/repos/AuthManager.kt
+++ b/data/src/main/java/com/android254/data/repos/AuthManager.kt
@@ -21,13 +21,12 @@ import com.android254.domain.repos.AuthRepo
 import ke.droidcon.kotlin.datasource.remote.auth.AuthApi
 import ke.droidcon.kotlin.datasource.remote.auth.model.GoogleToken
 import ke.droidcon.kotlin.datasource.remote.di.IoDispatcher
-import ke.droidcon.kotlin.datasource.remote.utils.NetworkError
-import ke.droidcon.kotlin.datasource.remote.utils.ServerError
 import ke.droidcon.kotlin.datasource.remote.utils.TokenProvider
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
+import ke.droidcon.kotlin.datasource.remote.utils.DataResult as RemoteDataResult
 
 @Singleton
 class AuthManager
@@ -39,19 +38,19 @@ class AuthManager
     ) : AuthRepo {
         override suspend fun getAndSaveApiToken(idToken: String): DataResult<Success> =
             withContext(ioDispatcher) {
-                try {
-                    val result = api.googleLogin(GoogleToken(idToken))
-                    tokenProvider.update(result.token)
-                    DataResult.Success(Success)
-                } catch (e: Exception) {
-                    when (e) {
-                        is ServerError, is NetworkError -> {
-                            DataResult.Error("Login failed", networkError = true, exc = e)
-                        }
-                        else -> {
-                            DataResult.Error("Login failed", exc = e)
-                        }
+                when (val result = api.googleLogin(GoogleToken(idToken))) {
+                    is RemoteDataResult.Success -> {
+                        tokenProvider.update(result.data.token)
+                        DataResult.Success(Success)
                     }
+                    is RemoteDataResult.Error ->
+                        DataResult.Error(
+                            message = "Login failed",
+                            networkError = result.networkError,
+                            exc = result.exc,
+                        )
+                    is RemoteDataResult.Loading, RemoteDataResult.Empty ->
+                        DataResult.Error("Login failed")
                 }
             }
     }

--- a/data/src/test/java/com/android254/data/repos/AuthManagerTest.kt
+++ b/data/src/test/java/com/android254/data/repos/AuthManagerTest.kt
@@ -25,7 +25,6 @@ import io.mockk.mockk
 import ke.droidcon.kotlin.datasource.remote.auth.AuthApi
 import ke.droidcon.kotlin.datasource.remote.auth.model.AccessTokenDTO
 import ke.droidcon.kotlin.datasource.remote.auth.model.UserDetailsDTO
-import ke.droidcon.kotlin.datasource.remote.utils.NetworkError
 import ke.droidcon.kotlin.datasource.remote.utils.TokenProvider
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -33,6 +32,7 @@ import kotlinx.coroutines.runBlocking
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
+import ke.droidcon.kotlin.datasource.remote.utils.DataResult as RemoteDataResult
 
 class AuthManagerTest {
     private val mockApi = mockk<AuthApi>()
@@ -52,9 +52,11 @@ class AuthManagerTest {
         runBlocking {
             val repo = AuthManager(mockApi, mockTokenProvider, ioDispatcher)
             coEvery { mockApi.googleLogin(any()) } returns
-                AccessTokenDTO(
-                    "test",
-                    user = fakeUserDetails,
+                RemoteDataResult.Success(
+                    AccessTokenDTO(
+                        "test",
+                        user = fakeUserDetails,
+                    ),
                 )
             coEvery { mockTokenProvider.update(any()) } just Runs
 
@@ -68,9 +70,10 @@ class AuthManagerTest {
     fun `test getAndSaveApiToken failure - network error`() {
         runBlocking {
             val repo = AuthManager(mockApi, mockTokenProvider, ioDispatcher)
-            val exc = NetworkError()
+            val exc = Exception("offline")
 
-            coEvery { mockApi.googleLogin(any()) } throws exc
+            coEvery { mockApi.googleLogin(any()) } returns
+                RemoteDataResult.Error("Network error", networkError = true, exc = exc)
             val result = repo.getAndSaveApiToken("test")
             assertThat(result, `is`(DataResult.Error("Login failed", true, exc)))
         }
@@ -82,7 +85,8 @@ class AuthManagerTest {
             val repo = AuthManager(mockApi, mockTokenProvider, ioDispatcher)
             val exc = Exception()
 
-            coEvery { mockApi.googleLogin(any()) } throws exc
+            coEvery { mockApi.googleLogin(any()) } returns
+                RemoteDataResult.Error("Client error", exc = exc)
             val result = repo.getAndSaveApiToken("test")
             assertThat(result, `is`(DataResult.Error("Login failed", exc = exc)))
         }

--- a/datasource/remote/src/main/java/ke/droidcon/kotlin/datasource/remote/auth/AuthApi.kt
+++ b/datasource/remote/src/main/java/ke/droidcon/kotlin/datasource/remote/auth/AuthApi.kt
@@ -22,8 +22,9 @@ import io.ktor.client.request.setBody
 import ke.droidcon.kotlin.datasource.remote.auth.model.AccessTokenDTO
 import ke.droidcon.kotlin.datasource.remote.auth.model.GoogleToken
 import ke.droidcon.kotlin.datasource.remote.auth.model.StatusDTO
+import ke.droidcon.kotlin.datasource.remote.utils.DataResult
+import ke.droidcon.kotlin.datasource.remote.utils.dataResultSafeApiCall
 import ke.droidcon.kotlin.datasource.remote.utils.provideBaseUrl
-import ke.droidcon.kotlin.datasource.remote.utils.safeApiCall
 import javax.inject.Inject
 
 class AuthApi
@@ -31,17 +32,17 @@ class AuthApi
     constructor(
         private val client: HttpClient,
     ) {
-        suspend fun googleLogin(token: GoogleToken): AccessTokenDTO =
-            safeApiCall {
-                return@safeApiCall client
+        suspend fun googleLogin(token: GoogleToken): DataResult<AccessTokenDTO> =
+            dataResultSafeApiCall {
+                client
                     .post("${provideBaseUrl()}/social_login/google") {
                         setBody(token)
                     }.body()
             }
 
-        suspend fun logout(): StatusDTO =
-            safeApiCall {
+        suspend fun logout(): DataResult<StatusDTO> =
+            dataResultSafeApiCall {
                 val url = "${provideBaseUrl()}/logout"
-                return@safeApiCall client.post(url).body()
+                client.post(url).body()
             }
     }

--- a/datasource/remote/src/main/java/ke/droidcon/kotlin/datasource/remote/sessions/RemoteSessionsDataSourceImpl.kt
+++ b/datasource/remote/src/main/java/ke/droidcon/kotlin/datasource/remote/sessions/RemoteSessionsDataSourceImpl.kt
@@ -25,11 +25,15 @@ class RemoteSessionsDataSourceImpl(
     private val api: SessionsApi,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : RemoteSessionsDataSource {
-    override suspend fun getAllSessionsRemote(): DataResult<List<SessionDTO>> {
-        return withContext(ioDispatcher) {
-            val response = api.fetchSessions()
-            val sessions = response.data.flatMap { (_, value) -> value }
-            return@withContext DataResult.Success(data = sessions)
+    override suspend fun getAllSessionsRemote(): DataResult<List<SessionDTO>> =
+        withContext(ioDispatcher) {
+            when (val response = api.fetchSessions()) {
+                is DataResult.Success ->
+                    DataResult.Success(
+                        data = response.data.data.flatMap { (_, value) -> value },
+                    )
+                is DataResult.Error -> response
+                is DataResult.Loading, DataResult.Empty -> DataResult.Empty
+            }
         }
-    }
 }

--- a/datasource/remote/src/main/java/ke/droidcon/kotlin/datasource/remote/sessions/SessionsApi.kt
+++ b/datasource/remote/src/main/java/ke/droidcon/kotlin/datasource/remote/sessions/SessionsApi.kt
@@ -19,8 +19,9 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import ke.droidcon.kotlin.datasource.remote.sessions.model.EventScheduleGroupedResponse
+import ke.droidcon.kotlin.datasource.remote.utils.DataResult
+import ke.droidcon.kotlin.datasource.remote.utils.dataResultSafeApiCall
 import ke.droidcon.kotlin.datasource.remote.utils.provideEventBaseUrl
-import ke.droidcon.kotlin.datasource.remote.utils.safeApiCall
 import javax.inject.Inject
 
 class SessionsApi
@@ -28,9 +29,9 @@ class SessionsApi
     constructor(
         private val client: HttpClient,
     ) {
-        suspend fun fetchSessions(): EventScheduleGroupedResponse =
-            safeApiCall {
-                return@safeApiCall client
+        suspend fun fetchSessions(): DataResult<EventScheduleGroupedResponse> =
+            dataResultSafeApiCall {
+                client
                     .get("${provideEventBaseUrl()}/schedule") {
                         url {
                             parameters.append("grouped", "true")

--- a/datasource/remote/src/main/java/ke/droidcon/kotlin/datasource/remote/utils/SafeApiCall.kt
+++ b/datasource/remote/src/main/java/ke/droidcon/kotlin/datasource/remote/utils/SafeApiCall.kt
@@ -24,49 +24,6 @@ import timber.log.Timber
 import java.io.IOException
 import java.nio.channels.UnresolvedAddressException
 
-/**
- * Runs a network call, mapping failures to [ServerError] or [NetworkError].
- *
- * An offline device surfaces [UnresolvedAddressException] rather than a connect timeout,
- * so every connectivity type is listed. [IOException] comes last because several Ktor
- * exceptions also extend it.
- */
-@Deprecated("Use dataResultSafeApiCall")
-suspend fun <T> safeApiCall(block: suspend () -> T): T =
-    try {
-        block()
-    } catch (e: ServerResponseException) {
-        Timber.e(e)
-        throw ServerError(e)
-    } catch (e: NoTransformationFoundException) {
-        Timber.e(e)
-        throw ServerError(e)
-    } catch (e: UnresolvedAddressException) {
-        Timber.e(e)
-        throw NetworkError(e)
-    } catch (e: ConnectTimeoutException) {
-        Timber.e(e)
-        throw NetworkError(e)
-    } catch (e: SocketTimeoutException) {
-        Timber.e(e)
-        throw NetworkError(e)
-    } catch (e: HttpRequestTimeoutException) {
-        Timber.e(e)
-        throw NetworkError(e)
-    } catch (e: IOException) {
-        Timber.e(e)
-        throw NetworkError(e)
-    }
-
-class ServerError(
-    cause: Throwable,
-) : Exception(cause)
-
-/** A connectivity failure. [cause] is retained so crash reports stay distinguishable. */
-class NetworkError(
-    cause: Throwable? = null,
-) : Exception(cause)
-
 suspend fun <T : Any> dataResultSafeApiCall(apiCall: suspend () -> T): DataResult<T> =
     try {
         DataResult.Success(apiCall.invoke())

--- a/datasource/remote/src/test/java/ke/droidcon/kotlin/datasource/remote/auth/AuthApiTest.kt
+++ b/datasource/remote/src/test/java/ke/droidcon/kotlin/datasource/remote/auth/AuthApiTest.kt
@@ -22,12 +22,13 @@ import ke.droidcon.kotlin.datasource.remote.auth.model.AccessTokenDTO
 import ke.droidcon.kotlin.datasource.remote.auth.model.GoogleToken
 import ke.droidcon.kotlin.datasource.remote.auth.model.StatusDTO
 import ke.droidcon.kotlin.datasource.remote.auth.model.UserDetailsDTO
+import ke.droidcon.kotlin.datasource.remote.utils.DataResult
 import ke.droidcon.kotlin.datasource.remote.utils.HttpClientFactory
 import ke.droidcon.kotlin.datasource.remote.utils.MockTokenProvider
 import ke.droidcon.kotlin.datasource.remote.utils.RemoteFeatureToggle
-import ke.droidcon.kotlin.datasource.remote.utils.ServerError
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import org.hamcrest.CoreMatchers.instanceOf
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
@@ -46,8 +47,8 @@ class AuthApiTest {
         remoteFeatureToggleTest = RemoteFeatureToggle(mockk(relaxed = true))
     }
 
-    @Test(expected = ServerError::class)
-    fun `test ServerError is thrown when a server exception occurs`() {
+    @Test
+    fun `test a server exception surfaces as DataResult Error`() {
         val mockEngine =
             MockEngine {
                 delay(500)
@@ -56,7 +57,9 @@ class AuthApiTest {
         val httpClient = HttpClientFactory(MockTokenProvider(), remoteFeatureToggleTest).create(mockEngine)
         val api = AuthApi(httpClient)
         runBlocking {
-            api.logout()
+            val response = api.logout()
+            assertThat(response, instanceOf(DataResult.Error::class.java))
+            assertThat((response as DataResult.Error).message, `is`("Server error"))
         }
     }
 
@@ -74,7 +77,7 @@ class AuthApiTest {
         val api = AuthApi(httpClient)
         runBlocking {
             val response = api.logout()
-            assertThat(response, `is`(StatusDTO("Success")))
+            assertThat(response, `is`(DataResult.Success(StatusDTO("Success")) as DataResult<StatusDTO>))
         }
     }
 
@@ -116,7 +119,7 @@ class AuthApiTest {
                         ),
                 )
             val response = api.googleLogin(GoogleToken("some token"))
-            assertThat(response, `is`(accessToken))
+            assertThat(response, `is`(DataResult.Success(accessToken) as DataResult<AccessTokenDTO>))
         }
     }
 }

--- a/datasource/remote/src/test/java/ke/droidcon/kotlin/datasource/remote/session/SessionApiTest.kt
+++ b/datasource/remote/src/test/java/ke/droidcon/kotlin/datasource/remote/session/SessionApiTest.kt
@@ -22,6 +22,7 @@ import io.ktor.http.headersOf
 import io.mockk.mockk
 import ke.droidcon.kotlin.datasource.remote.sessions.SessionsApi
 import ke.droidcon.kotlin.datasource.remote.sessions.model.EventScheduleGroupedResponse
+import ke.droidcon.kotlin.datasource.remote.utils.DataResult
 import ke.droidcon.kotlin.datasource.remote.utils.HttpClientFactory
 import ke.droidcon.kotlin.datasource.remote.utils.MockTokenProvider
 import ke.droidcon.kotlin.datasource.remote.utils.RemoteFeatureToggle
@@ -66,7 +67,7 @@ class SessionApiTest {
             // WHEN
             val response = SessionsApi(httpClient).fetchSessions()
             // THEN
-            assertThat(response, `is`(expectedResponse))
+            assertThat(response, `is`(DataResult.Success(expectedResponse) as DataResult<EventScheduleGroupedResponse>))
         }
     }
 }

--- a/datasource/remote/src/test/java/ke/droidcon/kotlin/datasource/remote/utils/SafeApiCallTest.kt
+++ b/datasource/remote/src/test/java/ke/droidcon/kotlin/datasource/remote/utils/SafeApiCallTest.kt
@@ -78,17 +78,4 @@ class SafeApiCallTest {
 
             assertEquals(DataResult.Success("ok"), result)
         }
-
-    @Suppress("DEPRECATION")
-    @Test
-    fun `safeApiCall maps offline failures to NetworkError and keeps the cause`() =
-        runTest {
-            val cause = UnresolvedAddressException()
-
-            val thrown =
-                runCatching { safeApiCall<String> { throw cause } }.exceptionOrNull()
-
-            assertTrue(thrown is NetworkError)
-            assertEquals(cause, thrown!!.cause)
-        }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,6 +62,7 @@ core = "1.7.0"
 nav3Core = "1.1.6"
 lifecycleViewmodelNav3 = "2.11.0"
 kotlinxSerializationCore = "1.11.0"
+collectionsImmutable = "0.5.1"
 
 [libraries]
 android-appCompat = { module = "androidx.appcompat:appcompat", version.ref = "app_compat" }
@@ -135,6 +136,7 @@ ktor-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktor" }
 ktor-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 
+kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "collectionsImmutable" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerializationCore" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationCore" }
 

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     implementation(libs.lottie.compose)
     implementation(libs.kotlin.coroutines.datetime)
     implementation(libs.bundles.serialization)
+    implementation(libs.kotlinx.collections.immutable)
 
     implementation(libs.bundles.navigation3)
     implementation(libs.bundles.coil)

--- a/presentation/src/main/java/com/android254/presentation/about/view/AboutScreen.kt
+++ b/presentation/src/main/java/com/android254/presentation/about/view/AboutScreen.kt
@@ -56,6 +56,9 @@ import com.droidconke.chai.components.ChaiBodyMedium
 import com.droidconke.chai.components.ChaiBodyMediumBold
 import com.droidconke.chai.components.ChaiTitle
 import ke.droidcon.kotlin.presentation.R
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun AboutRoute(
@@ -134,7 +137,7 @@ private fun AboutScreen(
 
                     OrganizedBySection(
                         modifier = Modifier.padding(start = 20.dp, end = 20.dp),
-                        organizationLogos = stakeHolderLogos,
+                        organizationLogos = stakeHolderLogos.toImmutableList(),
                     )
 
                     Spacer(modifier = Modifier.height(40.dp))
@@ -194,7 +197,7 @@ fun AboutDroidconSection(
 @Composable
 fun OrganizingTeamSection(
     modifier: Modifier = Modifier,
-    organizingTeam: List<OrganizingTeamMember>,
+    organizingTeam: ImmutableList<OrganizingTeamMember>,
     onClickMember: (Int) -> Unit,
 ) {
     Column(
@@ -243,7 +246,7 @@ private fun AboutScreenPreview() {
             uiState =
                 AboutScreenUiState.Success(
                     teamMembers =
-                        listOf(
+                        persistentListOf(
                             OrganizingTeamMember(
                                 name = "Member 1",
                                 desc = "Description 1",
@@ -276,7 +279,7 @@ private fun AboutScreenPreview() {
                             ),
                         ),
                     stakeHoldersLogos =
-                        listOf(
+                        persistentListOf(
                             "",
                             "",
                             "",

--- a/presentation/src/main/java/com/android254/presentation/about/view/AboutScreen.kt
+++ b/presentation/src/main/java/com/android254/presentation/about/view/AboutScreen.kt
@@ -149,8 +149,8 @@ private fun AboutScreen(
 
 @Composable
 fun AboutDroidconSection(
-    modifier: Modifier = Modifier,
     droidconDesc: String,
+    modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier,
@@ -196,8 +196,8 @@ fun AboutDroidconSection(
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun OrganizingTeamSection(
-    modifier: Modifier = Modifier,
     organizingTeam: ImmutableList<OrganizingTeamMember>,
+    modifier: Modifier = Modifier,
     onClickMember: (Int) -> Unit,
 ) {
     Column(

--- a/presentation/src/main/java/com/android254/presentation/about/view/AboutScreen.kt
+++ b/presentation/src/main/java/com/android254/presentation/about/view/AboutScreen.kt
@@ -237,7 +237,7 @@ fun OrganizingTeamSection(
     uiMode = Configuration.UI_MODE_NIGHT_YES,
 )
 @Composable
-fun AboutScreenPreview() {
+private fun AboutScreenPreview() {
     ChaiTheme {
         AboutScreen(
             uiState =

--- a/presentation/src/main/java/com/android254/presentation/about/view/AboutViewModel.kt
+++ b/presentation/src/main/java/com/android254/presentation/about/view/AboutViewModel.kt
@@ -20,6 +20,8 @@ import androidx.lifecycle.viewModelScope
 import com.android254.domain.repos.OrganizersRepo
 import com.android254.presentation.models.OrganizingTeamMember
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
@@ -31,7 +33,7 @@ sealed interface AboutScreenUiState {
     object Loading : AboutScreenUiState
 
     data class Success(
-        val teamMembers: List<OrganizingTeamMember>,
+        val teamMembers: ImmutableList<OrganizingTeamMember>,
         val stakeHoldersLogos: List<String>,
     ) : AboutScreenUiState
 
@@ -59,7 +61,7 @@ class AboutViewModel
                             )
                         }
                     val stakeholders = organizers.filterNot { it.type == "individual" }.map { it.photo }
-                    AboutScreenUiState.Success(teamMembers = team, stakeHoldersLogos = stakeholders)
+                    AboutScreenUiState.Success(teamMembers = team.toImmutableList(), stakeHoldersLogos = stakeholders)
                 }.onStart { AboutScreenUiState.Loading }
                 .catch { AboutScreenUiState.Error(message = "An unexpected error occurred") }
                 .stateIn(

--- a/presentation/src/main/java/com/android254/presentation/about/view/OrganizingTeamComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/about/view/OrganizingTeamComponent.kt
@@ -94,7 +94,7 @@ fun OrganizingTeamComponent(
 
 @ChaiLightAndDarkComposePreviews
 @Composable
-fun Preview() {
+private fun Preview() {
     ChaiTheme {
         OrganizingTeamComponent(
             modifier = Modifier,

--- a/presentation/src/main/java/com/android254/presentation/about/view/OrganizingTeamComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/about/view/OrganizingTeamComponent.kt
@@ -47,8 +47,8 @@ import ke.droidcon.kotlin.chai.R as ChaiR
 
 @Composable
 fun OrganizingTeamComponent(
-    modifier: Modifier = Modifier,
     teamMember: OrganizingTeamMember,
+    modifier: Modifier = Modifier,
     onClickMember: (Int) -> Unit,
 ) {
     Column(

--- a/presentation/src/main/java/com/android254/presentation/activity/MainActivity.kt
+++ b/presentation/src/main/java/com/android254/presentation/activity/MainActivity.kt
@@ -21,9 +21,11 @@ import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
@@ -59,6 +61,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         splashScreen.setKeepOnScreenCondition { viewModel.isInitialising.value }
@@ -135,7 +138,8 @@ fun MainScreen(
         Column(
             modifier =
                 Modifier
-                    .padding(padding),
+                    .padding(padding)
+                    .consumeWindowInsets(padding),
         ) {
             if (showAuthDialog) {
                 AuthDialog(

--- a/presentation/src/main/java/com/android254/presentation/activity/MainActivity.kt
+++ b/presentation/src/main/java/com/android254/presentation/activity/MainActivity.kt
@@ -105,6 +105,7 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 fun MainScreen(
+    modifier: Modifier = Modifier,
     viewModel: MainViewModel = hiltViewModel(),
     authViewModel: AuthViewModel = hiltViewModel(),
 ) {
@@ -121,7 +122,7 @@ fun MainScreen(
     }
 
     Scaffold(
-        modifier = Modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize(),
         bottomBar = {
             if (bottomBarState.value) {
                 BottomNavigationBar(

--- a/presentation/src/main/java/com/android254/presentation/activity/MainViewModel.kt
+++ b/presentation/src/main/java/com/android254/presentation/activity/MainViewModel.kt
@@ -23,6 +23,7 @@ import com.android254.presentation.sessions.mappers.toPresentationModel
 import com.android254.presentation.sessions.models.SessionUIState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import ke.droidcon.kotlin.datasource.remote.utils.RemoteFeatureToggle
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -91,13 +92,13 @@ class MainViewModel
                     ) { current, upNext ->
                         SessionUIState(
                             current =
-                                current.map {
-                                    it.toPresentationModel(now)
-                                },
+                                current
+                                    .map { it.toPresentationModel(now) }
+                                    .toImmutableList(),
                             upNext =
-                                upNext.map {
-                                    it.toPresentationModel(now)
-                                },
+                                upNext
+                                    .map { it.toPresentationModel(now) }
+                                    .toImmutableList(),
                         )
                     }
                 }.stateIn(

--- a/presentation/src/main/java/com/android254/presentation/auth/view/AuthDialog.kt
+++ b/presentation/src/main/java/com/android254/presentation/auth/view/AuthDialog.kt
@@ -128,7 +128,7 @@ fun AuthDialog(
 
 @ChaiLightAndDarkComposePreviews
 @Composable
-fun AuthDialogPreview() {
+private fun AuthDialogPreview() {
     ChaiTheme {
         AuthDialog()
     }

--- a/presentation/src/main/java/com/android254/presentation/common/bottomnav/BottomNavigationBar.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/bottomnav/BottomNavigationBar.kt
@@ -62,11 +62,12 @@ import kotlinx.collections.immutable.toImmutableList
 fun BottomNavigationBar(
     navController: NavigationController,
     navigationState: NavigationState,
+    modifier: Modifier = Modifier,
     currentSessions: ImmutableList<SessionPresentationModel> = persistentListOf(),
     upNextSessions: ImmutableList<SessionPresentationModel> = persistentListOf(),
 ) {
     Column(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Bottom),
     ) {
         LazyRow(
@@ -117,6 +118,7 @@ fun RowScope.BottomNavItem(
     isSelected: Boolean,
     destination: TopLevelDestination,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val label = stringResource(destination.label)
 
@@ -136,7 +138,7 @@ fun RowScope.BottomNavItem(
 
     Column(
         modifier =
-            Modifier
+            modifier
                 .weight(1f)
                 .fillMaxHeight()
                 .selectable(

--- a/presentation/src/main/java/com/android254/presentation/common/bottomnav/BottomNavigationBar.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/bottomnav/BottomNavigationBar.kt
@@ -54,13 +54,16 @@ import com.android254.presentation.sessions.components.CurrentSessionComponent
 import com.droidconke.chai.ChaiTheme
 import com.droidconke.chai.chaiColorsPalette
 import com.droidconke.chai.components.ChaiTextLabelSmall
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun BottomNavigationBar(
     navController: NavigationController,
     navigationState: NavigationState,
-    currentSessions: List<SessionPresentationModel> = emptyList(),
-    upNextSessions: List<SessionPresentationModel> = emptyList(),
+    currentSessions: ImmutableList<SessionPresentationModel> = persistentListOf(),
+    upNextSessions: ImmutableList<SessionPresentationModel> = persistentListOf(),
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -177,8 +180,8 @@ private fun BottomNavigationBarPreview() {
             BottomNavigationBar(
                 navController = navController,
                 navigationState = navigationState,
-                currentSessions = fakeSessions.filter { it.sessionStatus == SessionStatus.Ongoing }.take(2),
-                upNextSessions = fakeSessions.filter { it.sessionStatus == SessionStatus.Upcoming }.take(2),
+                currentSessions = fakeSessions.filter { it.sessionStatus == SessionStatus.Ongoing }.take(2).toImmutableList(),
+                upNextSessions = fakeSessions.filter { it.sessionStatus == SessionStatus.Upcoming }.take(2).toImmutableList(),
             )
         }
     }

--- a/presentation/src/main/java/com/android254/presentation/common/bottomnav/BottomNavigationBar.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/bottomnav/BottomNavigationBar.kt
@@ -162,7 +162,7 @@ fun RowScope.BottomNavItem(
 
 @PreviewLightDark
 @Composable
-fun BottomNavigationBarPreview() {
+private fun BottomNavigationBarPreview() {
     ChaiTheme {
         val navigationState =
             rememberNavigationState(

--- a/presentation/src/main/java/com/android254/presentation/common/components/AnimatedShimmerEffect.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/components/AnimatedShimmerEffect.kt
@@ -24,10 +24,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import kotlinx.collections.immutable.ImmutableList
 
 @Composable
 fun AnimatedShimmerEffect(
-    gradientColors: List<Color>,
+    gradientColors: ImmutableList<Color>,
     content: @Composable ((Brush) -> Unit),
 ) {
     val transition = rememberInfiniteTransition()

--- a/presentation/src/main/java/com/android254/presentation/common/components/DroidConTextField.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/components/DroidConTextField.kt
@@ -28,7 +28,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun DroidConTextField(label: String) {
+fun DroidConTextField(
+    label: String,
+    modifier: Modifier = Modifier,
+) {
     var value by remember {
         mutableStateOf("")
     }
@@ -37,7 +40,7 @@ fun DroidConTextField(label: String) {
         value = value,
         onValueChange = { value = it },
         label = { Text(label) },
-        modifier = Modifier.fillMaxWidth().padding(0.dp).height(48.dp),
+        modifier = modifier.fillMaxWidth().padding(0.dp).height(48.dp),
         colors =
             TextFieldDefaults.colors(
                 focusedIndicatorColor = Color.Transparent,

--- a/presentation/src/main/java/com/android254/presentation/common/components/DroidconAppBar.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/components/DroidconAppBar.kt
@@ -57,7 +57,7 @@ fun DroidconAppBar(
 
 @Preview
 @Composable
-fun DroidconAppBarPreview() {
+private fun DroidconAppBarPreview() {
     ChaiTheme {
         DroidconAppBar()
     }

--- a/presentation/src/main/java/com/android254/presentation/common/components/DroidconAppBarWithFeedbackButton.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/components/DroidconAppBarWithFeedbackButton.kt
@@ -101,7 +101,7 @@ fun FeedbackButton(
 
 @ChaiLightAndDarkComposePreviews
 @Composable
-fun Preview() {
+private fun Preview() {
     ChaiTheme {
         DroidconAppBarWithFeedbackButton(
             onButtonClick = {},

--- a/presentation/src/main/java/com/android254/presentation/common/components/DroidconAppBarWithFeedbackButton.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/components/DroidconAppBarWithFeedbackButton.kt
@@ -40,9 +40,9 @@ import ke.droidcon.kotlin.presentation.R
 
 @Composable
 fun DroidconAppBarWithFeedbackButton(
-    modifier: Modifier = Modifier,
     onButtonClick: () -> Unit,
     userProfile: String,
+    modifier: Modifier = Modifier,
 ) {
     Row(
         modifier =

--- a/presentation/src/main/java/com/android254/presentation/common/components/DroidconAppBarWithFilter.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/components/DroidconAppBarWithFilter.kt
@@ -150,7 +150,7 @@ fun FilterButton(
 
 @ChaiLightAndDarkComposePreviews
 @Composable
-fun ToolbarPreview() {
+private fun ToolbarPreview() {
     ChaiTheme {
         Column {
             DroidconAppBarWithFilter(

--- a/presentation/src/main/java/com/android254/presentation/common/components/DroidconAppBarWithFilter.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/components/DroidconAppBarWithFilter.kt
@@ -38,11 +38,11 @@ import ke.droidcon.kotlin.presentation.R
 
 @Composable
 fun DroidconAppBarWithFilter(
-    modifier: Modifier = Modifier,
     isListActive: Boolean,
     onListIconClick: () -> Unit,
     onAgendaIconClick: () -> Unit,
     isFilterActive: Boolean,
+    modifier: Modifier = Modifier,
     onFilterButtonClick: () -> Unit,
 ) {
     Row(
@@ -76,9 +76,9 @@ fun DroidconAppBarWithFilter(
 
 @Composable
 fun LayoutIconButtons(
-    modifier: Modifier = Modifier,
     isListActive: Boolean,
     onListIconClick: () -> Unit,
+    modifier: Modifier = Modifier,
     onAgendaIconClick: () -> Unit,
 ) {
     val listIconColor = if (isListActive) MaterialTheme.chaiColorsPalette.secondaryButtonColor else MaterialTheme.chaiColorsPalette.radioButtonColors
@@ -117,8 +117,8 @@ fun LayoutIconButtons(
 
 @Composable
 fun FilterButton(
-    modifier: Modifier = Modifier,
     isActive: Boolean,
+    modifier: Modifier = Modifier,
     onButtonClick: () -> Unit,
 ) {
     val stateColors = if (isActive) MaterialTheme.chaiColorsPalette.secondaryButtonColor else ChaiGrey

--- a/presentation/src/main/java/com/android254/presentation/common/components/FullscreenDialog.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/components/FullscreenDialog.kt
@@ -62,6 +62,7 @@ internal fun AnimatedModalBottomSheetTransition(
 @Composable
 fun FullscreenDialog(
     onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
     dismissOnBackPress: Boolean = true,
     content: @Composable (ModalTransitionDialogHelper) -> Unit,
 ) {
@@ -83,7 +84,9 @@ fun FullscreenDialog(
         onDismissRequest = { coroutineScope.launch { startDismissWithExitAnimation(animateContentBackTrigger, onDismissRequest) } },
         properties = DialogProperties(usePlatformDefaultWidth = false, dismissOnBackPress = dismissOnBackPress, dismissOnClickOutside = false),
     ) {
-        Box(Modifier.fillMaxSize()) {
+        Box(
+            modifier.fillMaxSize(),
+        ) {
             // Required in order to occupy the whole screen before the animation is triggered
             AnimatedModalBottomSheetTransition(visible = animateContentBackTrigger.value) {
                 content(ModalTransitionDialogHelper(coroutineScope, onCloseSharedFlow))

--- a/presentation/src/main/java/com/android254/presentation/common/components/Loader.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/components/Loader.kt
@@ -28,9 +28,15 @@ import com.airbnb.lottie.compose.rememberLottieComposition
 import ke.droidcon.kotlin.presentation.R
 
 @Composable
-fun Loader(message: String = "Loading...") {
+fun Loader(
+    modifier: Modifier = Modifier,
+    message: String = "Loading...",
+) {
     val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.loading))
-    Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(
+        modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
         LottieAnimation(
             composition = composition,
         )

--- a/presentation/src/main/java/com/android254/presentation/common/components/LoadingBox.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/components/LoadingBox.kt
@@ -34,6 +34,7 @@ import com.droidconke.chai.chaiColorsPalette
 @Composable
 fun LoadingBox(
     height: Dp,
+    modifier: Modifier = Modifier,
     width: Dp = 0.dp,
     widthRatio: Float? = null,
     cornerRadius: Dp = 5.dp,
@@ -42,7 +43,7 @@ fun LoadingBox(
 ) {
     Box(
         modifier =
-            Modifier
+            modifier
                 .customWidth(widthRatio, width)
                 .height(height)
                 .clip(RoundedCornerShape(cornerRadius))

--- a/presentation/src/main/java/com/android254/presentation/common/components/OrganizedBySection.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/components/OrganizedBySection.kt
@@ -39,8 +39,8 @@ import ke.droidcon.kotlin.chai.R as ChaiR
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun OrganizedBySection(
-    modifier: Modifier = Modifier,
     organizationLogos: ImmutableList<String>,
+    modifier: Modifier = Modifier,
 ) {
     Column(
         modifier =

--- a/presentation/src/main/java/com/android254/presentation/common/components/OrganizedBySection.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/components/OrganizedBySection.kt
@@ -33,13 +33,14 @@ import coil.request.ImageRequest
 import com.droidconke.chai.chaiColorsPalette
 import com.droidconke.chai.components.ChaiTitle
 import ke.droidcon.kotlin.presentation.R
+import kotlinx.collections.immutable.ImmutableList
 import ke.droidcon.kotlin.chai.R as ChaiR
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun OrganizedBySection(
     modifier: Modifier = Modifier,
-    organizationLogos: List<String>,
+    organizationLogos: ImmutableList<String>,
 ) {
     Column(
         modifier =

--- a/presentation/src/main/java/com/android254/presentation/common/components/SessionsCard.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/components/SessionsCard.kt
@@ -154,15 +154,13 @@ fun SessionsCard(
 }
 
 @Composable
-fun RowScope.SessionTimeComponent(
+fun SessionTimeComponent(
     sessionStartTime: String,
     sessionAmOrPm: String,
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier =
-            modifier
-                .weight(0.2f),
+        modifier = modifier,
         horizontalAlignment = Alignment.End,
     ) {
         ChaiBodyLargeBold(
@@ -232,12 +230,10 @@ fun RowScope.SessionDetails(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier =
-            Modifier
-                .weight(0.8f),
+        modifier = modifier.weight(1f),
     ) {
         SessionTitleComponent(session, onBookMark)
-        Spacer(modifier = modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(12.dp))
         SessionsDescriptionComponent(session.description)
         Spacer(modifier = Modifier.height(12.dp))
         TimeAndVenueComponent(session)
@@ -300,20 +296,19 @@ fun TimeAndVenueComponent(
     session: SessionPresentationModel,
     modifier: Modifier = Modifier,
 ) {
-    Row(modifier = modifier) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
         ChaiBodyXSmall(
             bodyText = "${session.startTime} - ${session.endTime}",
             textColor = MaterialTheme.chaiColorsPalette.textWeakColor,
+            maxLines = 1,
         )
-        Spacer(modifier = Modifier.width(16.dp))
-        ChaiBodyXSmall(
-            bodyText = "|",
-            textColor = MaterialTheme.chaiColorsPalette.textWeakColor,
-        )
-        Spacer(modifier = Modifier.width(12.dp))
         ChaiBodyXSmall(
             bodyText = session.venue.uppercase(),
             textColor = MaterialTheme.chaiColorsPalette.textWeakColor,
+            maxLines = 2,
         )
     }
 }

--- a/presentation/src/main/java/com/android254/presentation/common/components/SessionsCard.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/components/SessionsCard.kt
@@ -75,6 +75,7 @@ fun SessionsCard(
     session: SessionPresentationModel,
     navigateToSessionDetails: (sessionId: String) -> Unit,
     onBookmark: (String) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val venueAccent = venueAccentColor(session.venue)
 
@@ -113,7 +114,7 @@ fun SessionsCard(
 
     Card(
         modifier =
-            Modifier
+            modifier
                 .fillMaxWidth()
                 .wrapContentHeight()
                 .alpha(alpha),
@@ -156,10 +157,11 @@ fun SessionsCard(
 fun RowScope.SessionTimeComponent(
     sessionStartTime: String,
     sessionAmOrPm: String,
+    modifier: Modifier = Modifier,
 ) {
     Column(
         modifier =
-            Modifier
+            modifier
                 .weight(0.2f),
         horizontalAlignment = Alignment.End,
     ) {
@@ -227,6 +229,7 @@ private fun RowScope.NowIndicator(
 fun RowScope.SessionDetails(
     session: SessionPresentationModel,
     onBookMark: (String) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Column(
         modifier =
@@ -234,7 +237,7 @@ fun RowScope.SessionDetails(
                 .weight(0.8f),
     ) {
         SessionTitleComponent(session, onBookMark)
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = modifier.height(12.dp))
         SessionsDescriptionComponent(session.description)
         Spacer(modifier = Modifier.height(12.dp))
         TimeAndVenueComponent(session)
@@ -293,8 +296,11 @@ fun SessionsDescriptionComponent(sessionDescription: String) {
 }
 
 @Composable
-fun TimeAndVenueComponent(session: SessionPresentationModel) {
-    Row {
+fun TimeAndVenueComponent(
+    session: SessionPresentationModel,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier) {
         ChaiBodyXSmall(
             bodyText = "${session.startTime} - ${session.endTime}",
             textColor = MaterialTheme.chaiColorsPalette.textWeakColor,
@@ -315,8 +321,10 @@ fun TimeAndVenueComponent(session: SessionPresentationModel) {
 @Composable
 fun SessionPresenterComponents(
     speaker: SessionSpeakersPresentationModel,
+    modifier: Modifier = Modifier,
 ) {
     Row(
+        modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
     ) {
         AsyncImage(

--- a/presentation/src/main/java/com/android254/presentation/common/components/SponsorsCard.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/components/SponsorsCard.kt
@@ -50,8 +50,8 @@ import ke.droidcon.kotlin.chai.R as ChaiR
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun SponsorsCard(
-    modifier: Modifier = Modifier,
     sponsors: ImmutableList<SponsorPresentationModel>,
+    modifier: Modifier = Modifier,
 ) {
     Card {
         Column(

--- a/presentation/src/main/java/com/android254/presentation/common/components/SponsorsCard.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/components/SponsorsCard.kt
@@ -44,13 +44,14 @@ import com.android254.presentation.models.SponsorPresentationModel
 import com.droidconke.chai.chaiColorsPalette
 import com.droidconke.chai.components.ChaiSubTitle
 import ke.droidcon.kotlin.presentation.R
+import kotlinx.collections.immutable.ImmutableList
 import ke.droidcon.kotlin.chai.R as ChaiR
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun SponsorsCard(
     modifier: Modifier = Modifier,
-    sponsors: List<SponsorPresentationModel>,
+    sponsors: ImmutableList<SponsorPresentationModel>,
 ) {
     Card {
         Column(

--- a/presentation/src/main/java/com/android254/presentation/common/components/ToggleButtonGroup.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/components/ToggleButtonGroup.kt
@@ -39,11 +39,13 @@ import com.droidconke.chai.atoms.ChaiGrey90
 import com.droidconke.chai.atoms.ChaiTeal
 import com.droidconke.chai.chaiColorsPalette
 import com.droidconke.chai.components.ChaiBodySmall
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun MultiToggleButton(
-    currentSelections: List<SessionsFilterOption>,
-    toggleStates: List<SessionsFilterOption>,
+    currentSelections: ImmutableList<SessionsFilterOption>,
+    toggleStates: ImmutableList<SessionsFilterOption>,
     modifier: Modifier = Modifier,
     borderSize: Dp = 1.dp,
     buttonHeight: Dp = 40.dp,
@@ -101,9 +103,9 @@ fun MultiToggleButton(
                     elevation = ButtonDefaults.buttonElevation(),
                     enabled = enabled,
                     buttonTexts =
-                        filterOptions.map {
-                            it.label
-                        },
+                        filterOptions
+                            .map { it.label }
+                            .toImmutableList(),
                     index = index,
                     contentColor = contentColor,
                     onClick = {
@@ -122,7 +124,7 @@ private fun ToggleButton(
     backgroundColor: Color,
     elevation: ButtonElevation,
     enabled: Boolean,
-    buttonTexts: List<String>,
+    buttonTexts: ImmutableList<String>,
     index: Int,
     contentColor: Color,
     modifier: Modifier = Modifier,
@@ -148,7 +150,7 @@ private fun ToggleButton(
 
 @Composable
 private fun RowScope.ButtonContent(
-    buttonTexts: List<String>,
+    buttonTexts: ImmutableList<String>,
     index: Int,
     contentColor: Color,
 ) {
@@ -165,7 +167,7 @@ private fun RowScope.ButtonContent(
 
 @Composable
 private fun TextContent(
-    buttonTexts: List<String>,
+    buttonTexts: ImmutableList<String>,
     index: Int,
     contentColor: Color,
     modifier: Modifier = Modifier,

--- a/presentation/src/main/java/com/android254/presentation/common/divider/CustomDivider.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/divider/CustomDivider.kt
@@ -18,12 +18,14 @@ package com.android254.presentation.common.divider
 import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.droidconke.chai.chaiColorsPalette
 
 @Composable
-fun CustomDivider() {
+fun CustomDivider(modifier: Modifier = Modifier) {
     Divider(
+        modifier = modifier,
         thickness = 1.dp,
         color = MaterialTheme.chaiColorsPalette.surfaces,
     )

--- a/presentation/src/main/java/com/android254/presentation/common/fakedata/FakeSessions.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/fakedata/FakeSessions.kt
@@ -18,6 +18,7 @@ package com.android254.presentation.common.fakedata
 import com.android254.presentation.models.SessionPresentationModel
 import com.android254.presentation.models.SessionSpeakersPresentationModel
 import com.android254.presentation.models.SessionStatus
+import kotlinx.collections.immutable.persistentListOf
 
 private const val SAPPHIRE_OPAL = "Sapphire,Opal"
 private const val SAPPHIRE = "Sapphire"
@@ -28,7 +29,7 @@ private const val TIME_11_00 = "11:00"
 private const val LEVEL_INTERMEDIATE = "Intermediate"
 
 val fakeSessions =
-    listOf(
+    persistentListOf(
         SessionPresentationModel(
             id = "1",
             title = "Opening Keynote: Building for Africa",
@@ -46,7 +47,7 @@ val fakeSessions =
             remoteId = "remote_1",
             eventDay = "14",
             speakers =
-                listOf(
+                persistentListOf(
                     SessionSpeakersPresentationModel(
                         name = "Florence Mwangangi",
                         speakerImage = "",
@@ -71,7 +72,7 @@ val fakeSessions =
             remoteId = "remote_2",
             eventDay = "14",
             speakers =
-                listOf(
+                persistentListOf(
                     SessionSpeakersPresentationModel(
                         name = "Donald Okara",
                         speakerImage = "",
@@ -96,7 +97,7 @@ val fakeSessions =
             remoteId = "remote_3",
             isService = true,
             eventDay = "14",
-            speakers = emptyList(),
+            speakers = persistentListOf(),
         ),
         SessionPresentationModel(
             id = "4",
@@ -115,7 +116,7 @@ val fakeSessions =
             remoteId = "remote_4",
             eventDay = "14",
             speakers =
-                listOf(
+                persistentListOf(
                     SessionSpeakersPresentationModel(
                         name = "Brian Kimani",
                         speakerImage = "",
@@ -140,7 +141,7 @@ val fakeSessions =
             remoteId = "remote_5",
             isService = true,
             eventDay = "14",
-            speakers = emptyList(),
+            speakers = persistentListOf(),
         ),
         SessionPresentationModel(
             id = "6",
@@ -159,7 +160,7 @@ val fakeSessions =
             remoteId = "remote_6",
             eventDay = "14",
             speakers =
-                listOf(
+                persistentListOf(
                     SessionSpeakersPresentationModel(
                         name = "Amina Yusuf",
                         speakerImage = "",
@@ -183,7 +184,7 @@ val fakeSessions =
             remoteId = "remote_7",
             eventDay = "14",
             speakers =
-                listOf(
+                persistentListOf(
                     SessionSpeakersPresentationModel(
                         name = "Kevin Omondi",
                         speakerImage = "",
@@ -207,7 +208,7 @@ val fakeSessions =
             remoteId = "remote_8",
             eventDay = "14",
             speakers =
-                listOf(
+                persistentListOf(
                     SessionSpeakersPresentationModel(
                         name = "Sarah Njeri",
                         speakerImage = "",
@@ -231,7 +232,7 @@ val fakeSessions =
             remoteId = "remote_9",
             eventDay = "15",
             speakers =
-                listOf(
+                persistentListOf(
                     SessionSpeakersPresentationModel(
                         name = "Grace Wambui",
                         speakerImage = "",
@@ -255,7 +256,7 @@ val fakeSessions =
             remoteId = "remote_10",
             eventDay = "15",
             speakers =
-                listOf(
+                persistentListOf(
                     SessionSpeakersPresentationModel(
                         name = "Ian Otieno",
                         speakerImage = "",

--- a/presentation/src/main/java/com/android254/presentation/common/navigation/Navigation.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/navigation/Navigation.kt
@@ -24,10 +24,10 @@ import androidx.navigation3.ui.NavDisplay
 
 @Composable
 fun Navigation(
-    modifier: Modifier = Modifier,
     navController: NavigationController,
     navigationState: NavigationState,
     updateBottomBarState: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
     onActionClicked: () -> Unit = {},
     entryProvider: (NavKey) -> NavEntry<NavKey> =
         droidconEntryProvider(

--- a/presentation/src/main/java/com/android254/presentation/common/navigation/NavigationState.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/navigation/NavigationState.kt
@@ -32,6 +32,7 @@ import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.runtime.serialization.NavKeySerializer
 import androidx.savedstate.compose.serialization.serializers.MutableStateSerializer
+import kotlinx.collections.immutable.ImmutableSet
 
 /**
  * Remembers and creates a [NavigationState] to manage multi-stack navigation.
@@ -46,7 +47,7 @@ import androidx.savedstate.compose.serialization.serializers.MutableStateSeriali
 @Composable
 fun rememberNavigationState(
     startRoute: NavKey,
-    topLevelRoutes: Set<NavKey>,
+    topLevelRoutes: ImmutableSet<NavKey>,
 ): NavigationState {
     val topLevelRoute =
         rememberSerializable(

--- a/presentation/src/main/java/com/android254/presentation/common/navigation/Screens.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/navigation/Screens.kt
@@ -16,6 +16,7 @@
 package com.android254.presentation.common.navigation
 
 import androidx.navigation3.runtime.NavKey
+import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.serialization.Serializable
 
 /**
@@ -57,4 +58,4 @@ sealed interface Screens : NavKey {
 
 val bottomNavigationRoutes: List<Screens> = TopLevelDestination.routes
 
-val bottomNavigationSet: Set<Screens> = TopLevelDestination.routeSet
+val bottomNavigationSet: ImmutableSet<Screens> = TopLevelDestination.routeSet

--- a/presentation/src/main/java/com/android254/presentation/common/navigation/TopLevelDestination.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/navigation/TopLevelDestination.kt
@@ -18,6 +18,8 @@ package com.android254.presentation.common.navigation
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import ke.droidcon.kotlin.presentation.R
+import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.toImmutableSet
 import ke.droidcon.kotlin.chai.R as ChaiR
 
 /**
@@ -37,7 +39,7 @@ enum class TopLevelDestination(
 
     companion object {
         val routes: List<Screens> = entries.map { it.route }
-        val routeSet: Set<Screens> = routes.toSet()
+        val routeSet: ImmutableSet<Screens> = routes.toImmutableSet()
 
         fun of(route: Screens): TopLevelDestination? = entries.firstOrNull { it.route == route }
     }

--- a/presentation/src/main/java/com/android254/presentation/common/stepper/VerticalStepComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/stepper/VerticalStepComponent.kt
@@ -208,10 +208,10 @@ fun <T> VerticalStepItem(
 
 @Composable
 private fun IconBox(
-    modifier: Modifier = Modifier,
     icon: ImageVector,
     accentColor: Color,
     sizeInt: Int,
+    modifier: Modifier = Modifier,
     intensity: Intensity = Intensity.Medium,
 ) {
     val colorScheme = MaterialTheme.colorScheme

--- a/presentation/src/main/java/com/android254/presentation/feed/view/FeedComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/feed/view/FeedComponent.kt
@@ -127,7 +127,7 @@ fun FeedComponent(
 
 @Preview
 @Composable
-fun Preview() {
+private fun Preview() {
     ChaiTheme {
         FeedComponent(
             modifier = Modifier,

--- a/presentation/src/main/java/com/android254/presentation/feed/view/FeedLoadingComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/feed/view/FeedLoadingComponent.kt
@@ -34,10 +34,10 @@ import com.droidconke.chai.ChaiTheme
 import com.droidconke.chai.chaiColorsPalette
 
 @Composable
-fun FeedLoadingComponent() {
+fun FeedLoadingComponent(modifier: Modifier = Modifier) {
     Column(
         modifier =
-            Modifier
+            modifier
                 .background(color = MaterialTheme.chaiColorsPalette.background)
                 .fillMaxWidth()
                 .padding(horizontal = 20.dp, vertical = 10.dp),

--- a/presentation/src/main/java/com/android254/presentation/feed/view/FeedLoadingComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/feed/view/FeedLoadingComponent.kt
@@ -61,7 +61,7 @@ fun FeedLoadingComponent() {
 
 @ChaiLightAndDarkComposePreviews
 @Composable
-fun FeedLoadingComponentPreview() {
+private fun FeedLoadingComponentPreview() {
     ChaiTheme {
         FeedLoadingComponent()
     }

--- a/presentation/src/main/java/com/android254/presentation/feed/view/FeedScreen.kt
+++ b/presentation/src/main/java/com/android254/presentation/feed/view/FeedScreen.kt
@@ -201,7 +201,7 @@ private fun FeedScreen(
     uiMode = Configuration.UI_MODE_NIGHT_YES,
 )
 @Composable
-fun FeedScreenPreview() {
+private fun FeedScreenPreview() {
     ChaiTheme {
         Surface(modifier = Modifier.background(MaterialTheme.colorScheme.surface)) {
             FeedScreen(

--- a/presentation/src/main/java/com/android254/presentation/feed/view/FeedShareSection.kt
+++ b/presentation/src/main/java/com/android254/presentation/feed/view/FeedShareSection.kt
@@ -146,7 +146,7 @@ fun PlatformButton(
 
 @ChaiLightAndDarkComposePreviews
 @Composable
-fun PlatformButtonPreview() {
+private fun PlatformButtonPreview() {
     ChaiTheme {
         PlatformButton("Twitter", R.drawable.ic_whatsapp)
     }
@@ -154,7 +154,7 @@ fun PlatformButtonPreview() {
 
 @ChaiLightAndDarkComposePreviews
 @Composable
-fun PFeedShareSectionPreview() {
+private fun PFeedShareSectionPreview() {
     ChaiTheme {
         FeedShareSection()
     }

--- a/presentation/src/main/java/com/android254/presentation/feed/view/FeedShareSection.kt
+++ b/presentation/src/main/java/com/android254/presentation/feed/view/FeedShareSection.kt
@@ -49,11 +49,12 @@ import ke.droidcon.kotlin.presentation.R
 
 @Composable
 fun FeedShareSection(
+    modifier: Modifier = Modifier,
     onCancelClicked: () -> Unit = {},
 ) {
     Column(
         modifier =
-            Modifier
+            modifier
                 .fillMaxWidth()
                 .background(color = MaterialTheme.chaiColorsPalette.bottomSheetBackgroundColor)
                 .padding(start = 20.dp, top = 36.dp, end = 16.dp, bottom = 48.dp)
@@ -115,12 +116,13 @@ fun FeedShareSection(
 fun PlatformButton(
     platform: String,
     icon: Int,
+    modifier: Modifier = Modifier,
 ) {
     OutlinedButton(
         onClick = { /*TODO*/ },
         shape = MaterialTheme.shapes.small,
         modifier =
-            Modifier
+            modifier
                 .fillMaxWidth()
                 .padding(6.dp),
         border = BorderStroke(1.dp, ChaiTeal90),

--- a/presentation/src/main/java/com/android254/presentation/feedback/view/FeedBackScreen.kt
+++ b/presentation/src/main/java/com/android254/presentation/feedback/view/FeedBackScreen.kt
@@ -323,9 +323,9 @@ private fun FeedBackScreen(
 }
 
 @Composable
-fun FeedbackTitle() {
+fun FeedbackTitle(modifier: Modifier = Modifier) {
     ChaiBodyLarge(
-        modifier = Modifier.testTag("heading"),
+        modifier = modifier.testTag("heading"),
         bodyText = stringResource(R.string.feedback_label),
     )
 }

--- a/presentation/src/main/java/com/android254/presentation/feedback/view/FeedBackScreen.kt
+++ b/presentation/src/main/java/com/android254/presentation/feedback/view/FeedBackScreen.kt
@@ -339,7 +339,7 @@ fun FeedbackTitle() {
     uiMode = Configuration.UI_MODE_NIGHT_YES,
 )
 @Composable
-fun FeedBackScreenPreview() {
+private fun FeedBackScreenPreview() {
     ChaiTheme {
         FeedBackScreen(darkTheme = isSystemInDarkTheme())
     }

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeBannerSection.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeBannerSection.kt
@@ -57,12 +57,12 @@ fun HomeBannerSection(homeViewState: HomeViewState) {
 }
 
 @Composable
-fun HomeEventPoster() {
+fun HomeEventPoster(modifier: Modifier = Modifier) {
     Image(
         painter = painterResource(id = R.drawable.droidcon_event_banner),
         contentDescription = stringResource(id = R.string.home_banner_event_poster_description),
         modifier =
-            Modifier
+            modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(20.dp))
                 .testTag("home_event_poster"),
@@ -71,11 +71,11 @@ fun HomeEventPoster() {
 }
 
 @Composable
-fun HomeCallForSpeakersLink() {
+fun HomeCallForSpeakersLink(modifier: Modifier = Modifier) {
     Card(
         shape = RoundedCornerShape(20.dp),
         modifier =
-            Modifier
+            modifier
                 .fillMaxWidth()
                 .aspectRatio(4.2f)
                 .testTag("home_call_for_speakers_link"),

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeBannerSection.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeBannerSection.kt
@@ -123,7 +123,7 @@ fun HomeCallForSpeakersLink() {
 
 @Preview
 @Composable
-fun HomeBannerSectionPreview() {
+private fun HomeBannerSectionPreview() {
     ChaiTheme {
         HomeBannerSection(HomeViewState())
     }
@@ -131,7 +131,7 @@ fun HomeBannerSectionPreview() {
 
 @Preview
 @Composable
-fun HomeEventBannerPreview() {
+private fun HomeEventBannerPreview() {
     ChaiTheme {
         HomeEventPoster()
     }
@@ -139,7 +139,7 @@ fun HomeEventBannerPreview() {
 
 @Preview
 @Composable
-fun HomeCallForSpeakersLinkPreview() {
+private fun HomeCallForSpeakersLinkPreview() {
     ChaiTheme {
         HomeCallForSpeakersLink()
     }

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeHeaderSectionComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeHeaderSectionComponent.kt
@@ -27,9 +27,9 @@ import com.droidconke.chai.components.ChaiBodyMediumBold
 import ke.droidcon.kotlin.presentation.R
 
 @Composable
-fun HomeHeaderSectionComponent() {
+fun HomeHeaderSectionComponent(modifier: Modifier = Modifier) {
     ChaiBodyMediumBold(
-        modifier = Modifier.testTag("home_header"),
+        modifier = modifier.testTag("home_header"),
         bodyText = stringResource(id = R.string.home_header_welcome_label),
         textColor = MaterialTheme.chaiColorsPalette.textBoldColor,
     )

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeSessionLoadingComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeSessionLoadingComponent.kt
@@ -35,10 +35,10 @@ import com.droidconke.chai.components.ChaiSubTitle
 import ke.droidcon.kotlin.presentation.R
 
 @Composable
-fun HomeSessionLoadingComponent() {
+fun HomeSessionLoadingComponent(modifier: Modifier = Modifier) {
     Column(
         modifier =
-            Modifier
+            modifier
                 .fillMaxWidth()
                 .padding(bottom = 20.dp),
     ) {

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeSessionLoadingComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeSessionLoadingComponent.kt
@@ -66,7 +66,7 @@ fun HomeSessionLoadingComponent() {
 
 @Preview(showBackground = true)
 @Composable
-fun HomeSessionLoadingComponentPreview() {
+private fun HomeSessionLoadingComponentPreview() {
     ChaiTheme {
         HomeSessionLoadingComponent()
     }

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeSessionLoadingItem.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeSessionLoadingItem.kt
@@ -28,10 +28,10 @@ import com.android254.presentation.common.components.LoadingBox
 import com.droidconke.chai.ChaiTheme
 
 @Composable
-fun HomeSessionLoadingItem() {
+fun HomeSessionLoadingItem(modifier: Modifier = Modifier) {
     Column(
         modifier =
-            Modifier
+            modifier
                 .padding(horizontal = 8.dp, vertical = 10.dp),
         horizontalAlignment = Alignment.Start,
     ) {

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeSessionLoadingItem.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeSessionLoadingItem.kt
@@ -45,7 +45,7 @@ fun HomeSessionLoadingItem() {
 
 @Preview(showBackground = true)
 @Composable
-fun HomeSessionLoadingItemPreview() {
+private fun HomeSessionLoadingItemPreview() {
     ChaiTheme {
         HomeSessionLoadingItem()
     }

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeSessionSection.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeSessionSection.kt
@@ -43,11 +43,12 @@ import com.droidconke.chai.chaiColorsPalette
 import com.droidconke.chai.components.ChaiBodySmallBold
 import com.droidconke.chai.components.ChaiTextLabelLarge
 import ke.droidcon.kotlin.presentation.R
+import kotlinx.collections.immutable.ImmutableList
 
 @Composable
 fun HomeSessionSection(
     modifier: Modifier = Modifier,
-    sessions: List<SessionPresentationModel>,
+    sessions: ImmutableList<SessionPresentationModel>,
     onSessionClick: (sessionId: String) -> Unit,
     onViewAllSessionClicked: () -> Unit,
 ) {

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeSessionSection.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeSessionSection.kt
@@ -47,9 +47,9 @@ import kotlinx.collections.immutable.ImmutableList
 
 @Composable
 fun HomeSessionSection(
-    modifier: Modifier = Modifier,
     sessions: ImmutableList<SessionPresentationModel>,
     onSessionClick: (sessionId: String) -> Unit,
+    modifier: Modifier = Modifier,
     onViewAllSessionClicked: () -> Unit,
 ) {
     Column(

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeSpacer.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeSpacer.kt
@@ -22,4 +22,4 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun HomeSpacer() = Spacer(modifier = Modifier.padding(10.dp))
+fun HomeSpacer(modifier: Modifier = Modifier) = Spacer(modifier = modifier.padding(10.dp))

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeSpeakerComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeSpeakerComponent.kt
@@ -99,7 +99,7 @@ fun HomeSpeakerComponent(
 
 @Preview
 @Composable
-fun HomeSpeakerComponentPreview() {
+private fun HomeSpeakerComponentPreview() {
     ChaiTheme {
         Surface(color = Color.White) {
             HomeSpeakerComponent(

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeSpeakerComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeSpeakerComponent.kt
@@ -47,11 +47,12 @@ import ke.droidcon.kotlin.presentation.R
 @Composable
 fun HomeSpeakerComponent(
     speaker: SpeakerUI,
+    modifier: Modifier = Modifier,
     onClick: () -> Unit = {},
 ) {
     ConstraintLayout(
         modifier =
-            Modifier
+            modifier
                 .width(90.dp)
                 .clickable { onClick.invoke() },
     ) {

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeSpeakersLoadingComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeSpeakersLoadingComponent.kt
@@ -65,7 +65,7 @@ fun HomeSpeakersLoadingComponent() {
 
 @Preview(showBackground = true)
 @Composable
-fun HomeSpeakersLoadingComponentPreview() {
+private fun HomeSpeakersLoadingComponentPreview() {
     ChaiTheme {
         HomeSpeakersLoadingComponent()
     }

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeSpeakersLoadingComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeSpeakersLoadingComponent.kt
@@ -35,10 +35,10 @@ import com.droidconke.chai.components.ChaiSubTitle
 import ke.droidcon.kotlin.presentation.R
 
 @Composable
-fun HomeSpeakersLoadingComponent() {
+fun HomeSpeakersLoadingComponent(modifier: Modifier = Modifier) {
     Column(
         modifier =
-            Modifier
+            modifier
                 .fillMaxWidth(),
     ) {
         Row(

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeSpeakersLoadingItem.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeSpeakersLoadingItem.kt
@@ -28,9 +28,9 @@ import com.android254.presentation.common.components.LoadingBox
 import com.droidconke.chai.ChaiTheme
 
 @Composable
-fun HomeSpeakersLoadingItem() {
+fun HomeSpeakersLoadingItem(modifier: Modifier = Modifier) {
     Column(
-        modifier = Modifier.padding(horizontal = 8.dp, vertical = 10.dp),
+        modifier = modifier.padding(horizontal = 8.dp, vertical = 10.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         LoadingBox(height = 80.dp, width = 80.dp)

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeSpeakersLoadingItem.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeSpeakersLoadingItem.kt
@@ -41,7 +41,7 @@ fun HomeSpeakersLoadingItem() {
 
 @Preview(showBackground = true)
 @Composable
-fun HomeSpeakersLoadingItemPreview() {
+private fun HomeSpeakersLoadingItemPreview() {
     ChaiTheme {
         HomeSpeakersLoadingItem()
     }

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeSpeakersSection.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeSpeakersSection.kt
@@ -37,6 +37,7 @@ import kotlinx.collections.immutable.toImmutableList
 @Composable
 fun HomeSpeakersSection(
     speakers: ImmutableList<SpeakerUI>,
+    modifier: Modifier = Modifier,
     navigateToSpeakers: () -> Unit = {},
     navigateToSpeaker: (String) -> Unit = {},
 ) {
@@ -51,7 +52,7 @@ fun HomeSpeakersSection(
         )
         LazyRow(
             modifier =
-                Modifier
+                modifier
                     .testTag("speakersRow")
                     .padding(top = 24.dp),
             horizontalArrangement = Arrangement.spacedBy(16.dp),

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeSpeakersSection.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeSpeakersSection.kt
@@ -31,10 +31,12 @@ import com.android254.presentation.models.SpeakerUI
 import com.android254.presentation.models.speakersDummyData
 import com.droidconke.chai.ChaiTheme
 import ke.droidcon.kotlin.presentation.R
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun HomeSpeakersSection(
-    speakers: List<SpeakerUI>,
+    speakers: ImmutableList<SpeakerUI>,
     navigateToSpeakers: () -> Unit = {},
     navigateToSpeaker: (String) -> Unit = {},
 ) {
@@ -67,7 +69,7 @@ fun HomeSpeakersSection(
 @Composable
 private fun HomeSpeakersSectionPreview() {
     ChaiTheme {
-        HomeSpeakersSection(speakers = speakersDummyData)
+        HomeSpeakersSection(speakers = speakersDummyData.toImmutableList())
     }
 }
 

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeSpeakersSection.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeSpeakersSection.kt
@@ -65,7 +65,7 @@ fun HomeSpeakersSection(
 
 @Preview
 @Composable
-fun HomeSpeakersSectionPreview() {
+private fun HomeSpeakersSectionPreview() {
     ChaiTheme {
         HomeSpeakersSection(speakers = speakersDummyData)
     }

--- a/presentation/src/main/java/com/android254/presentation/home/mappers/DomainToPresentationMappers.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/mappers/DomainToPresentationMappers.kt
@@ -19,8 +19,10 @@ import com.android254.domain.models.Speaker
 import com.android254.domain.models.Sponsors
 import com.android254.presentation.models.SpeakerUI
 import com.android254.presentation.models.SponsorPresentationModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
-fun List<Speaker>.toSpeakersPresentation() =
+fun List<Speaker>.toSpeakersPresentation(): ImmutableList<SpeakerUI> =
     map {
         SpeakerUI(
             imageUrl = it.avatar,
@@ -29,7 +31,7 @@ fun List<Speaker>.toSpeakersPresentation() =
             bio = it.biography,
             twitterHandle = it.twitter,
         )
-    }
+    }.toImmutableList()
 
 fun Sponsors.toPresentation() =
     SponsorPresentationModel(

--- a/presentation/src/main/java/com/android254/presentation/home/screen/HomeScreen.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/screen/HomeScreen.kt
@@ -151,7 +151,7 @@ private fun HomeScreen(
 
 @ChaiLightAndDarkComposePreviews
 @Composable
-fun HomeScreenPreview() {
+private fun HomeScreenPreview() {
     ChaiTheme {
         HomeScreen(
             viewState =

--- a/presentation/src/main/java/com/android254/presentation/home/screen/HomeScreen.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/screen/HomeScreen.kt
@@ -43,6 +43,7 @@ import com.android254.presentation.utils.ChaiLightAndDarkComposePreviews
 import com.droidconke.chai.ChaiTheme
 import com.droidconke.chai.chaiColorsPalette
 import com.droidconke.chai.components.ChaiPullToRefreshBox
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 fun HomeRoute(
@@ -160,12 +161,12 @@ private fun HomeScreenPreview() {
                     isCallForSpeakersVisible = true,
                     linkToCallForSpeakers = "https://droidconke.com",
                     isSignedIn = false,
-                    speakers = listOf(),
+                    speakers = persistentListOf(),
                     isSpeakersSectionVisible = true,
                     isSessionsSectionVisible = true,
-                    sponsors = listOf(),
-                    organizedBy = listOf(),
-                    sessions = listOf(),
+                    sponsors = persistentListOf(),
+                    organizedBy = persistentListOf(),
+                    sessions = persistentListOf(),
                 ),
             isSyncing = false,
         )

--- a/presentation/src/main/java/com/android254/presentation/home/viewmodel/HomeViewModel.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/viewmodel/HomeViewModel.kt
@@ -24,6 +24,7 @@ import com.android254.presentation.home.mappers.toSpeakersPresentation
 import com.android254.presentation.home.viewstate.HomeViewState
 import com.android254.presentation.sessions.mappers.toPresentationModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
@@ -60,9 +61,9 @@ class HomeViewModel
                         speakers = it.speakers.toSpeakersPresentation(),
                         isSpeakersSectionVisible = it.isSpeakersSessionEnable,
                         isSessionsSectionVisible = it.isSessionsSectionEnable,
-                        sponsors = it.sponsors.map { sponsor -> sponsor.toPresentation() },
+                        sponsors = it.sponsors.map { sponsor -> sponsor.toPresentation() }.toImmutableList(),
                         organizedBy = it.organizers.map { organizer -> organizer.organizerLogoUrl },
-                        sessions = it.sessions.map { session -> session.toPresentationModel(clock.now()) },
+                        sessions = it.sessions.map { session -> session.toPresentationModel(clock.now()) }.toImmutableList(),
                     )
                 }.stateIn(
                     scope = viewModelScope,

--- a/presentation/src/main/java/com/android254/presentation/home/viewstate/HomeViewState.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/viewstate/HomeViewState.kt
@@ -18,16 +18,18 @@ package com.android254.presentation.home.viewstate
 import com.android254.presentation.models.SessionPresentationModel
 import com.android254.presentation.models.SpeakerUI
 import com.android254.presentation.models.SponsorPresentationModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 data class HomeViewState(
     val isPosterVisible: Boolean = true,
     val isCallForSpeakersVisible: Boolean = false,
     val linkToCallForSpeakers: String = "",
     val isSignedIn: Boolean = false,
-    val speakers: List<SpeakerUI> = emptyList(),
+    val speakers: ImmutableList<SpeakerUI> = persistentListOf(),
     val isSpeakersSectionVisible: Boolean = false,
-    val sponsors: List<SponsorPresentationModel> = emptyList(),
+    val sponsors: ImmutableList<SponsorPresentationModel> = persistentListOf(),
     val organizedBy: List<String> = emptyList(),
-    val sessions: List<SessionPresentationModel> = emptyList(),
+    val sessions: ImmutableList<SessionPresentationModel> = persistentListOf(),
     val isSessionsSectionVisible: Boolean = false,
 )

--- a/presentation/src/main/java/com/android254/presentation/models/SessionPresentationModel.kt
+++ b/presentation/src/main/java/com/android254/presentation/models/SessionPresentationModel.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.MicExternalOn
 import androidx.compose.ui.graphics.Color
 import com.android254.presentation.common.stepper.Intensity
 import com.android254.presentation.common.stepper.VerticalStep
+import kotlinx.collections.immutable.ImmutableList
 
 data class SessionPresentationModel(
     val id: String,
@@ -42,7 +43,7 @@ data class SessionPresentationModel(
     val sessionStatus: SessionStatus = SessionStatus.Upcoming,
     val sessionImage: String = "",
     val eventDay: String,
-    val speakers: List<SessionSpeakersPresentationModel>,
+    val speakers: ImmutableList<SessionSpeakersPresentationModel>,
 ) {
     val isServiceSession = isService && speakers.isEmpty()
     val isKeynote = format.contains("Keynote", ignoreCase = true)

--- a/presentation/src/main/java/com/android254/presentation/sessionDetails/view/SessionDetailsScreen.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessionDetails/view/SessionDetailsScreen.kt
@@ -220,7 +220,7 @@ fun Body(
     uiMode = Configuration.UI_MODE_NIGHT_YES,
 )
 @Composable
-fun SessionDetailsScreenPreview() {
+private fun SessionDetailsScreenPreview() {
     ChaiTheme {
         SessionDetailsScreen(
             onNavigationIconClick = {},

--- a/presentation/src/main/java/com/android254/presentation/sessionDetails/view/SessionDetailsScreen.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessionDetails/view/SessionDetailsScreen.kt
@@ -150,10 +150,11 @@ fun Body(
     sessionDetails: SessionDetailsPresentationModel,
     bookmarkSession: (String) -> Unit,
     unBookmarkSession: (String) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Column(
         modifier =
-            Modifier
+            modifier
                 .padding(paddingValues)
                 .fillMaxWidth()
                 .fillMaxHeight()

--- a/presentation/src/main/java/com/android254/presentation/sessionDetails/view/components/SessionBannerImage.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessionDetails/view/components/SessionBannerImage.kt
@@ -29,12 +29,15 @@ import com.android254.presentation.models.SessionDetailsPresentationModel
 import com.droidconke.chai.atoms.ChaiTeal90
 
 @Composable
-fun SessionBannerImage(sessionDetails: SessionDetailsPresentationModel) {
+fun SessionBannerImage(
+    sessionDetails: SessionDetailsPresentationModel,
+    modifier: Modifier = Modifier,
+) {
     AsyncImage(
         model = sessionDetails.sessionImageUrl,
         contentDescription = null,
         modifier =
-            Modifier
+            modifier
                 .fillMaxWidth()
                 .wrapContentHeight()
                 .border(1.dp, ChaiTeal90, RoundedCornerShape(10.dp))

--- a/presentation/src/main/java/com/android254/presentation/sessionDetails/view/components/SessionLevel.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessionDetails/view/components/SessionLevel.kt
@@ -28,10 +28,13 @@ import com.droidconke.chai.chaiColorsPalette
 import com.droidconke.chai.components.ChaiBodySmall
 
 @Composable
-fun SessionLevel(sessionLevel: String) {
+fun SessionLevel(
+    sessionLevel: String,
+    modifier: Modifier = Modifier,
+) {
     ChaiBodySmall(
         modifier =
-            Modifier
+            modifier
                 .background(
                     color = MaterialTheme.chaiColorsPalette.badgeBackgroundColor,
                     shape = RoundedCornerShape(5.dp),

--- a/presentation/src/main/java/com/android254/presentation/sessionDetails/view/components/SessionTimeAndRoom.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessionDetails/view/components/SessionTimeAndRoom.kt
@@ -31,9 +31,10 @@ import com.droidconke.chai.components.ChaiBodyXSmall
 @Composable
 fun SessionTimeAndRoom(
     sessionDetails: SessionDetailsPresentationModel,
+    modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
     ) {
         ChaiBodyXSmall(
             modifier = Modifier.testTag(TestTag.TIME_SLOT),

--- a/presentation/src/main/java/com/android254/presentation/sessionDetails/view/components/SpeakerTwitterHandle.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessionDetails/view/components/SpeakerTwitterHandle.kt
@@ -45,6 +45,7 @@ import ke.droidcon.kotlin.presentation.R
 @Composable
 fun SpeakerTwitterHandle(
     speaker: SessionDetailsSpeakerPresentationModel,
+    modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
     val intent =
@@ -56,7 +57,7 @@ fun SpeakerTwitterHandle(
         }
 
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {

--- a/presentation/src/main/java/com/android254/presentation/sessionDetails/view/components/TopBar.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessionDetails/view/components/TopBar.kt
@@ -31,9 +31,12 @@ import ke.droidcon.kotlin.presentation.R
 import ke.droidcon.kotlin.chai.R as ChaiR
 
 @Composable
-fun TopBar(onNavigationIconClick: () -> Unit) {
+fun TopBar(
+    onNavigationIconClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     TopAppBar(
-        modifier = Modifier.testTag(TestTag.TOP_BAR),
+        modifier = modifier.testTag(TestTag.TOP_BAR),
         colors =
             TopAppBarDefaults.topAppBarColors(
                 containerColor = MaterialTheme.chaiColorsPalette.background,

--- a/presentation/src/main/java/com/android254/presentation/sessions/components/CurrentSessionComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/components/CurrentSessionComponent.kt
@@ -182,7 +182,7 @@ fun CurrentSessionComponent(
 
 @PreviewLightDark
 @Composable
-fun CurrentSessionUpNextPreview() {
+private fun CurrentSessionUpNextPreview() {
     val defaultSession = fakeSessions.first()
     val session = fakeSessions.find { session -> session.sessionStatus == SessionStatus.Upcoming } ?: defaultSession
 
@@ -200,7 +200,7 @@ fun CurrentSessionUpNextPreview() {
 
 @PreviewLightDark
 @Composable
-fun CurrentSessionCurrentPreview() {
+private fun CurrentSessionCurrentPreview() {
     val defaultSession = fakeSessions.first()
     val session = fakeSessions.find { session -> session.sessionStatus == SessionStatus.Ongoing } ?: defaultSession
 

--- a/presentation/src/main/java/com/android254/presentation/sessions/components/CustomSwitch.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/components/CustomSwitch.kt
@@ -51,12 +51,13 @@ import com.droidconke.chai.components.ChaiTextLabelSmall
 
 @Composable
 fun CustomSwitch(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
     width: Dp = 56.dp,
     height: Dp = 32.dp,
     iconInnerPadding: Dp = 4.dp,
     thumbSize: Dp = 24.dp,
-    checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit,
 ) {
     // this is to disable the ripple effect
     val interactionSource =
@@ -68,7 +69,7 @@ fun CustomSwitch(
     val alignment by animateAlignmentAsState(if (checked) 1f else -1f)
 
     Column(
-        modifier = Modifier.wrapContentSize(),
+        modifier = modifier.wrapContentSize(),
         verticalArrangement = Arrangement.spacedBy(4.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {

--- a/presentation/src/main/java/com/android254/presentation/sessions/components/EventDaySelector.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/components/EventDaySelector.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.android254.presentation.models.EventDate
+import kotlinx.collections.immutable.ImmutableList
 
 fun ordinal(i: Int): String {
     val suffixes = arrayOf("th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th")
@@ -36,7 +37,7 @@ fun ordinal(i: Int): String {
 fun EventDaySelector(
     selectedDate: EventDate,
     updateSelectedDay: (EventDate) -> Unit,
-    eventDates: List<EventDate>,
+    eventDates: ImmutableList<EventDate>,
 ) {
     LazyRow {
         items(eventDates, key = { it.value }) { eventDay ->

--- a/presentation/src/main/java/com/android254/presentation/sessions/components/EventDaySelector.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/components/EventDaySelector.kt
@@ -38,6 +38,7 @@ fun EventDaySelector(
     selectedDate: EventDate,
     updateSelectedDay: (EventDate) -> Unit,
     eventDates: ImmutableList<EventDate>,
+    modifier: Modifier = Modifier,
 ) {
     LazyRow {
         items(eventDates, key = { it.value }) { eventDay ->
@@ -47,7 +48,9 @@ fun EventDaySelector(
                 onClick = { updateSelectedDay(eventDay) },
                 selected = selectedDate == eventDay,
             )
-            Spacer(Modifier.width(16.dp))
+            Spacer(
+                modifier.width(16.dp),
+            )
         }
     }
 }

--- a/presentation/src/main/java/com/android254/presentation/sessions/components/EventDaySelectorButton.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/components/EventDaySelectorButton.kt
@@ -40,12 +40,13 @@ fun EventDaySelectorButton(
     subtitle: String,
     selected: Boolean,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Column(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.Start,
         modifier =
-            Modifier
+            modifier
                 .size(51.dp)
                 .clickable { onClick() }
                 .background(

--- a/presentation/src/main/java/com/android254/presentation/sessions/components/SessionLoadingCard.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/components/SessionLoadingCard.kt
@@ -37,6 +37,7 @@ import com.android254.presentation.common.components.LoadingBox
 import com.android254.presentation.utils.ChaiLightAndDarkComposePreviews
 import com.droidconke.chai.ChaiTheme
 import com.droidconke.chai.chaiColorsPalette
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 fun SessionsLoadingCard() {
@@ -51,7 +52,7 @@ fun SessionsLoadingCard() {
     ) {
         AnimatedShimmerEffect(
             gradientColors =
-                listOf(
+                persistentListOf(
                     MaterialTheme.chaiColorsPalette.loadingStateOnCardsColor.copy(alpha = 0.3f),
                     MaterialTheme.chaiColorsPalette.loadingStateOnCardsColor.copy(alpha = 0.2f),
                     MaterialTheme.chaiColorsPalette.loadingStateOnCardsColor.copy(alpha = 0.3f),

--- a/presentation/src/main/java/com/android254/presentation/sessions/components/SessionLoadingCard.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/components/SessionLoadingCard.kt
@@ -101,7 +101,7 @@ fun SessionsLoadingCard() {
 
 @ChaiLightAndDarkComposePreviews
 @Composable
-fun SessionsLoadingComponentPreview() {
+private fun SessionsLoadingComponentPreview() {
     ChaiTheme {
         SessionsLoadingCard()
     }

--- a/presentation/src/main/java/com/android254/presentation/sessions/components/SessionLoadingCard.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/components/SessionLoadingCard.kt
@@ -40,10 +40,10 @@ import com.droidconke.chai.chaiColorsPalette
 import kotlinx.collections.immutable.persistentListOf
 
 @Composable
-fun SessionsLoadingCard() {
+fun SessionsLoadingCard(modifier: Modifier = Modifier) {
     Card(
         modifier =
-            Modifier
+            modifier
                 .fillMaxWidth()
                 .wrapContentHeight(),
         shape = RoundedCornerShape(5),

--- a/presentation/src/main/java/com/android254/presentation/sessions/components/SessionLoadingComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/components/SessionLoadingComponent.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.filled.CoPresent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android254.presentation.common.stepper.Intensity
@@ -31,7 +32,7 @@ import com.droidconke.chai.atoms.ChaiBlue
 import com.droidconke.chai.chaiColorsPalette
 
 @Composable
-fun SessionLoadingComponent() {
+fun SessionLoadingComponent(modifier: Modifier = Modifier) {
     val data =
         List(3) { index ->
             VerticalStep(
@@ -42,7 +43,7 @@ fun SessionLoadingComponent() {
                 data = Unit,
             )
         }
-    LazyColumn {
+    LazyColumn(modifier = modifier) {
         verticalSteps(
             items = data,
             spacing = 16.dp,

--- a/presentation/src/main/java/com/android254/presentation/sessions/components/SessionLoadingComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/components/SessionLoadingComponent.kt
@@ -54,7 +54,7 @@ fun SessionLoadingComponent() {
 
 @PreviewLightDark
 @Composable
-fun SessionLoadingPreview() {
+private fun SessionLoadingPreview() {
     ChaiTheme {
         Surface(
             color = MaterialTheme.chaiColorsPalette.background,

--- a/presentation/src/main/java/com/android254/presentation/sessions/components/SessionStateComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/components/SessionStateComponent.kt
@@ -202,7 +202,7 @@ fun SessionListComponent(
 
 @PreviewLightDark
 @Composable
-fun SessionListPreview() {
+private fun SessionListPreview() {
     ChaiTheme {
         Surface(
             color = MaterialTheme.chaiColorsPalette.background,

--- a/presentation/src/main/java/com/android254/presentation/sessions/components/SessionStateComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/components/SessionStateComponent.kt
@@ -58,6 +58,7 @@ import com.droidconke.chai.components.ChaiBodyMediumBold
 import com.droidconke.chai.components.ChaiPullToRefreshBox
 import com.droidconke.chai.components.ChaiSubTitle
 import ke.droidcon.kotlin.presentation.R
+import kotlinx.collections.immutable.ImmutableList
 import ke.droidcon.kotlin.chai.R as ChaiR
 
 @Composable
@@ -129,7 +130,7 @@ fun SessionsStateComponent(
 fun SessionListComponent(
     isRefreshing: Boolean,
     pullToRefreshState: PullToRefreshState,
-    sessions: List<SessionPresentationModel>,
+    sessions: ImmutableList<SessionPresentationModel>,
     sessionScreenState: SessionScreenState,
     isSessionLayoutList: Boolean,
     navigateToSessionDetails: (sessionId: String) -> Unit,

--- a/presentation/src/main/java/com/android254/presentation/sessions/components/SessionStateComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/components/SessionStateComponent.kt
@@ -154,6 +154,7 @@ fun SessionListComponent(
     ChaiPullToRefreshBox(
         isRefreshing = isRefreshing,
         onRefresh = { onEvent(SessionsIntentHandler.RefreshSessions) },
+        modifier = modifier,
         state = pullToRefreshState,
     ) {
         LazyColumn(
@@ -161,7 +162,7 @@ fun SessionListComponent(
             contentPadding = PaddingValues(bottom = 32.dp),
         ) {
             item {
-                Spacer(modifier = modifier.height(20.dp))
+                Spacer(modifier = Modifier.height(20.dp))
 
                 ChaiSubTitle(
                     titleText =

--- a/presentation/src/main/java/com/android254/presentation/sessions/components/SessionStateComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/components/SessionStateComponent.kt
@@ -69,6 +69,7 @@ fun SessionsStateComponent(
     sessionScreenState: SessionScreenState,
     isSessionLayoutList: Boolean,
     onEvent: (SessionsIntentHandler) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     // Hoisted above AnimatedContent so an in-flight pull survives a sessionStatus change.
     val pullToRefreshState = rememberPullToRefreshState()
@@ -78,7 +79,7 @@ fun SessionsStateComponent(
             is ResultStatus.Empty -> {
                 Column(
                     modifier =
-                        Modifier
+                        modifier
                             .fillMaxSize(),
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.Center,
@@ -135,6 +136,7 @@ fun SessionListComponent(
     isSessionLayoutList: Boolean,
     navigateToSessionDetails: (sessionId: String) -> Unit,
     onEvent: (SessionsIntentHandler) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val listState = rememberLazyListState()
 
@@ -159,7 +161,7 @@ fun SessionListComponent(
             contentPadding = PaddingValues(bottom = 32.dp),
         ) {
             item {
-                Spacer(modifier = Modifier.height(20.dp))
+                Spacer(modifier = modifier.height(20.dp))
 
                 ChaiSubTitle(
                     titleText =

--- a/presentation/src/main/java/com/android254/presentation/sessions/components/SessionsCardWithBannerImage.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/components/SessionsCardWithBannerImage.kt
@@ -62,9 +62,9 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun SessionsCardWithBannerImage(
-    modifier: Modifier = Modifier,
     session: SessionPresentationModel,
     navigateToSessionDetails: (sessionId: String) -> Unit,
+    modifier: Modifier = Modifier,
     viewModel: SessionsViewModel = hiltViewModel(),
 ) {
     val scope = rememberCoroutineScope()
@@ -130,9 +130,10 @@ fun SpeakerDetailsAndLikeButtonComponent(
     onBookmarkClicked: () -> Unit,
     isSessionStarred: Boolean,
     speakers: ImmutableList<SessionSpeakersPresentationModel>,
+    modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         speakers.forEach { speaker ->

--- a/presentation/src/main/java/com/android254/presentation/sessions/components/SessionsCardWithBannerImage.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/components/SessionsCardWithBannerImage.kt
@@ -57,6 +57,7 @@ import com.droidconke.chai.atoms.ChaiTeal
 import com.droidconke.chai.chaiColorsPalette
 import com.droidconke.chai.components.ChaiBodySmallBold
 import ke.droidcon.kotlin.presentation.R
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.launch
 
 @Composable
@@ -128,7 +129,7 @@ fun SessionsCardWithBannerImage(
 fun SpeakerDetailsAndLikeButtonComponent(
     onBookmarkClicked: () -> Unit,
     isSessionStarred: Boolean,
-    speakers: List<SessionSpeakersPresentationModel>,
+    speakers: ImmutableList<SessionSpeakersPresentationModel>,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),

--- a/presentation/src/main/java/com/android254/presentation/sessions/components/SessionsErrorComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/components/SessionsErrorComponent.kt
@@ -39,10 +39,11 @@ import ke.droidcon.kotlin.presentation.R
 @Composable
 fun SessionsErrorComponent(
     errorMessage: String,
+    modifier: Modifier = Modifier,
     retry: () -> Unit = {},
 ) {
     Column(
-        modifier = Modifier.fillMaxSize().padding(24.dp),
+        modifier = modifier.fillMaxSize().padding(24.dp),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {

--- a/presentation/src/main/java/com/android254/presentation/sessions/components/SessionsErrorComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/components/SessionsErrorComponent.kt
@@ -64,7 +64,7 @@ fun SessionsErrorComponent(
 
 @Preview
 @Composable
-fun SessionsErrorComponentPreview() {
+private fun SessionsErrorComponentPreview() {
     Surface(color = Color.White) {
         SessionsErrorComponent(errorMessage = "Something Went Wrong")
     }

--- a/presentation/src/main/java/com/android254/presentation/sessions/components/SessionsFilterPanel.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/components/SessionsFilterPanel.kt
@@ -48,12 +48,14 @@ import com.droidconke.chai.components.ChaiBodyLarge
 import com.droidconke.chai.components.ChaiSubTitle
 import com.droidconke.chai.components.ChaiTextButtonLight
 import ke.droidcon.kotlin.presentation.R
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun SessionsFilterPanel(
     onDismiss: () -> Unit,
-    selectableFilters: List<SessionsFilterOption>,
-    currentSelections: List<SessionsFilterOption>,
+    selectableFilters: ImmutableList<SessionsFilterOption>,
+    currentSelections: ImmutableList<SessionsFilterOption>,
     updateSelectedFilterOptionList: (SessionsFilterOption) -> Unit,
     clearSelectedFilterList: () -> Unit,
 ) {
@@ -123,7 +125,7 @@ fun SessionsFilterPanel(
                     )
                     Spacer(modifier = Modifier.height(12.dp))
                     MultiToggleButton(
-                        toggleStates = filter.value,
+                        toggleStates = filter.value.toImmutableList(),
                         onClick = {
                             updateSelectedFilterOptionList(it)
                         },

--- a/presentation/src/main/java/com/android254/presentation/sessions/components/SessionsFilterPanel.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/components/SessionsFilterPanel.kt
@@ -58,6 +58,7 @@ fun SessionsFilterPanel(
     currentSelections: ImmutableList<SessionsFilterOption>,
     updateSelectedFilterOptionList: (SessionsFilterOption) -> Unit,
     clearSelectedFilterList: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val groupedFilters =
         remember(selectableFilters) {
@@ -65,7 +66,7 @@ fun SessionsFilterPanel(
         }
     Column(
         modifier =
-            Modifier
+            modifier
                 .fillMaxSize()
                 .background(
                     color = ChaiGrey90.copy(alpha = 0.52f),

--- a/presentation/src/main/java/com/android254/presentation/sessions/mappers/SessionMapper.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/mappers/SessionMapper.kt
@@ -22,6 +22,8 @@ import com.android254.presentation.models.SessionDetailsSpeakerPresentationModel
 import com.android254.presentation.models.SessionPresentationModel
 import com.android254.presentation.models.SessionSpeakersPresentationModel
 import com.android254.presentation.models.SessionStatus
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import timber.log.Timber
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -101,14 +103,14 @@ fun List<Speaker>.toSessionDetailsSpeaker() =
         )
     }
 
-fun List<Speaker>.toSessionSpeaker() =
+fun List<Speaker>.toSessionSpeaker(): ImmutableList<SessionSpeakersPresentationModel> =
     map { speaker ->
         SessionSpeakersPresentationModel(
             speakerImage = speaker.avatar,
             name = speaker.name,
             twitterHandle = speaker.twitter,
         )
-    }
+    }.toImmutableList()
 
 fun getTimePeriod(time: String): FormattedTime {
     val parsed = time.toLocalDateTimeOrNull() ?: return FormattedTime(time = time, period = "")

--- a/presentation/src/main/java/com/android254/presentation/sessions/mappers/SessionMapper.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/mappers/SessionMapper.kt
@@ -53,7 +53,7 @@ fun Session.toPresentationModel(now: Instant): SessionPresentationModel {
         id = this.id,
         title = this.title,
         description = this.description,
-        venue = this.rooms,
+        venue = this.roomList.joinToString(", "),
         sessionStatus = sessionStatus,
         startTime = startTime.time,
         endTime = "${endTime.time} ${endTime.period}",
@@ -73,19 +73,20 @@ fun Session.toPresentationModel(now: Instant): SessionPresentationModel {
 
 fun Session.toSessionDetailsPresentationModal(): SessionDetailsPresentationModel {
     val startTime = getTimePeriod(this.startDateTime)
+    val endTime = getTimePeriod(this.endDateTime)
     return SessionDetailsPresentationModel(
         id = this.id,
         title = this.title,
         description = this.description,
-        venue = this.rooms,
+        venue = this.roomList.joinToString(", "),
         startTime = startTime.time,
-        endTime = this.endTime,
+        endTime = "${endTime.time} ${endTime.period}",
         amOrPm = startTime.period,
         isStarred = this.isBookmarked,
         level = this.sessionLevel,
         format = this.sessionFormat,
         sessionImageUrl = this.sessionImage.toString(),
-        timeSlot = "${startTime.time} - ${this.endTime}",
+        timeSlot = "${startTime.time} - ${endTime.time} ${endTime.period}",
         speakers = speakers.toSessionDetailsSpeaker(),
     )
 }

--- a/presentation/src/main/java/com/android254/presentation/sessions/models/SessionUIState.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/models/SessionUIState.kt
@@ -16,8 +16,10 @@
 package com.android254.presentation.sessions.models
 
 import com.android254.presentation.models.SessionPresentationModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 data class SessionUIState(
-    val current: List<SessionPresentationModel> = emptyList(),
-    val upNext: List<SessionPresentationModel> = emptyList(),
+    val current: ImmutableList<SessionPresentationModel> = persistentListOf(),
+    val upNext: ImmutableList<SessionPresentationModel> = persistentListOf(),
 )

--- a/presentation/src/main/java/com/android254/presentation/sessions/models/SessionsUiState.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/models/SessionsUiState.kt
@@ -19,13 +19,15 @@ import com.android254.presentation.common.resultstatus.ResultStatus
 import com.android254.presentation.models.EventDate
 import com.android254.presentation.models.SessionPresentationModel
 import com.android254.presentation.models.SessionsFilterOption
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 data class SessionsUiState(
-    val sessions: List<SessionPresentationModel> = emptyList(),
-    val eventDays: List<EventDate> = emptyList(),
+    val sessions: ImmutableList<SessionPresentationModel> = persistentListOf(),
+    val eventDays: ImmutableList<EventDate> = persistentListOf(),
     val sessionStatus: ResultStatus = ResultStatus.Loading,
     /** Derived from the loaded sessions, so no option can name a value no session has. */
-    val availableFilters: List<SessionsFilterOption> = emptyList(),
+    val availableFilters: ImmutableList<SessionsFilterOption> = persistentListOf(),
     val showMySessionsOnly: Boolean = false,
     val isFilterActive: Boolean = false,
 )

--- a/presentation/src/main/java/com/android254/presentation/sessions/view/SessionStateProvider.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/view/SessionStateProvider.kt
@@ -27,6 +27,7 @@ import com.android254.presentation.models.EventDate
 import com.android254.presentation.sessions.models.SessionsUiState
 import com.droidconke.chai.ChaiTheme
 import com.droidconke.chai.chaiColorsPalette
+import kotlinx.collections.immutable.persistentListOf
 
 @PreviewLightDark
 @Composable
@@ -41,7 +42,7 @@ private fun SessionScreenPreview(
                 sessionsUiState = state,
                 selectedEventDate = EventDate("2023-11-16", day = 1),
                 isRefreshing = false,
-                currentSelections = emptyList(),
+                currentSelections = persistentListOf(),
                 navigateToSessionDetails = {},
                 onEvent = {},
             )

--- a/presentation/src/main/java/com/android254/presentation/sessions/view/SessionStateProvider.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/view/SessionStateProvider.kt
@@ -50,7 +50,7 @@ private fun SessionScreenPreview(
     }
 }
 
-class SessionStateProvider : PreviewParameterProvider<SessionsUiState> {
+private class SessionStateProvider : PreviewParameterProvider<SessionsUiState> {
     override val values =
         sequenceOf(
             SessionsUiState(

--- a/presentation/src/main/java/com/android254/presentation/sessions/view/SessionStateProvider.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/view/SessionStateProvider.kt
@@ -30,7 +30,7 @@ import com.droidconke.chai.chaiColorsPalette
 
 @PreviewLightDark
 @Composable
-fun SessionScreenPreview(
+private fun SessionScreenPreview(
     @PreviewParameter(SessionStateProvider::class) state: SessionsUiState,
 ) {
     ChaiTheme {

--- a/presentation/src/main/java/com/android254/presentation/sessions/view/SessionsScreen.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/view/SessionsScreen.kt
@@ -51,6 +51,8 @@ import com.android254.presentation.utils.ChaiLightAndDarkComposePreviews
 import com.droidconke.chai.ChaiTheme
 import com.droidconke.chai.atoms.ChaiGrey90
 import com.droidconke.chai.chaiColorsPalette
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 fun SessionsRoute(
@@ -79,7 +81,7 @@ fun SessionsScreen(
     sessionsUiState: SessionsUiState,
     selectedEventDate: EventDate,
     isRefreshing: Boolean,
-    currentSelections: List<SessionsFilterOption>,
+    currentSelections: ImmutableList<SessionsFilterOption>,
     navigateToSessionDetails: (sessionId: String) -> Unit,
     onEvent: (SessionsIntentHandler) -> Unit,
 ) {
@@ -197,7 +199,7 @@ private fun SessionsScreenPreview() {
             sessionsUiState = SessionsUiState(),
             selectedEventDate = EventDate("1", day = 1),
             isRefreshing = false,
-            currentSelections = listOf(),
+            currentSelections = persistentListOf(),
             navigateToSessionDetails = {},
             onEvent = {},
         )

--- a/presentation/src/main/java/com/android254/presentation/sessions/view/SessionsScreen.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/view/SessionsScreen.kt
@@ -84,6 +84,7 @@ fun SessionsScreen(
     currentSelections: ImmutableList<SessionsFilterOption>,
     navigateToSessionDetails: (sessionId: String) -> Unit,
     onEvent: (SessionsIntentHandler) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     // Derived from the ViewModel rather than mirrored here, so rotation cannot leave the
     // switch and the applied filter disagreeing.
@@ -106,6 +107,7 @@ fun SessionsScreen(
     }
 
     Scaffold(
+        modifier = modifier,
         topBar = {
             DroidconAppBarWithFilter(
                 isListActive = isSessionLayoutList.value,

--- a/presentation/src/main/java/com/android254/presentation/sessions/view/SessionsScreen.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/view/SessionsScreen.kt
@@ -191,7 +191,7 @@ fun SessionsScreen(
 
 @ChaiLightAndDarkComposePreviews
 @Composable
-fun SessionsScreenPreview() {
+private fun SessionsScreenPreview() {
     ChaiTheme {
         SessionsScreen(
             sessionsUiState = SessionsUiState(),

--- a/presentation/src/main/java/com/android254/presentation/sessions/view/SessionsViewModel.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/view/SessionsViewModel.kt
@@ -191,7 +191,7 @@ class SessionsViewModel
 
         fun updateSelectedFilterOptionList(option: SessionsFilterOption) {
             _selectedFilterOptions.update { selected ->
-                if (option in selected) selected.remove(option) else selected.add(option)
+                if (option in selected) selected.removing(option) else selected.adding(option)
             }
             _filterState.update { it.toggle(option) }
         }

--- a/presentation/src/main/java/com/android254/presentation/sessions/view/SessionsViewModel.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/view/SessionsViewModel.kt
@@ -30,6 +30,9 @@ import com.android254.presentation.sessions.models.SessionsIntentHandler
 import com.android254.presentation.sessions.models.SessionsUiState
 import com.android254.presentation.sessions.utils.SessionsFilterCategory
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
@@ -54,8 +57,8 @@ class SessionsViewModel
         private val clock: Clock,
         @ConferenceTimeZone private val conferenceTimeZone: TimeZone,
     ) : ViewModel() {
-        private val _selectedFilterOptions: MutableStateFlow<List<SessionsFilterOption>> =
-            MutableStateFlow(emptyList())
+        private val _selectedFilterOptions: MutableStateFlow<PersistentList<SessionsFilterOption>> =
+            MutableStateFlow(persistentListOf())
         val selectedFilterOptions = _selectedFilterOptions.asStateFlow()
 
         private val _filterState = MutableStateFlow(SessionsFilterState())
@@ -86,10 +89,10 @@ class SessionsViewModel
                         )
 
                     SessionsUiState(
-                        sessions = filteredSessions,
-                        eventDays = sessionDays,
+                        sessions = filteredSessions.toImmutableList(),
+                        eventDays = sessionDays.toImmutableList(),
                         sessionStatus = getResultStatus(filteredSessions),
-                        availableFilters = buildFilterOptions(sessionsInformation.sessions),
+                        availableFilters = buildFilterOptions(sessionsInformation.sessions).toImmutableList(),
                         showMySessionsOnly = filterState.isBookmarked,
                         isFilterActive = filterState.isActive,
                     )
@@ -188,13 +191,13 @@ class SessionsViewModel
 
         fun updateSelectedFilterOptionList(option: SessionsFilterOption) {
             _selectedFilterOptions.update { selected ->
-                if (option in selected) selected - option else selected + option
+                if (option in selected) selected.remove(option) else selected.add(option)
             }
             _filterState.update { it.toggle(option) }
         }
 
         fun clearSelectedFilterList() {
-            _selectedFilterOptions.value = listOf()
+            _selectedFilterOptions.value = persistentListOf()
             _filterState.value = SessionsFilterState()
         }
 
@@ -203,7 +206,7 @@ class SessionsViewModel
         }
 
         fun refreshSessionList() {
-            _selectedFilterOptions.value = listOf()
+            _selectedFilterOptions.value = persistentListOf()
             _filterState.update {
                 SessionsFilterState(isBookmarked = it.isBookmarked)
             }

--- a/presentation/src/main/java/com/android254/presentation/speakers/SpeakersScreenViewModel.kt
+++ b/presentation/src/main/java/com/android254/presentation/speakers/SpeakersScreenViewModel.kt
@@ -21,6 +21,8 @@ import com.android254.domain.repos.SpeakersRepo
 import com.android254.domain.work.SyncDataWorkManager
 import com.android254.presentation.models.SpeakerUI
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
@@ -33,7 +35,7 @@ sealed interface SpeakersScreenUiState {
     object Loading : SpeakersScreenUiState
 
     data class Success(
-        val speakers: List<SpeakerUI>,
+        val speakers: ImmutableList<SpeakerUI>,
     ) : SpeakersScreenUiState
 
     data class Error(
@@ -60,17 +62,18 @@ class SpeakersScreenViewModel
             speakersRepo
                 .fetchSpeakers()
                 .map {
-                    it.map {
-                        SpeakerUI(
-                            id = 1,
-                            imageUrl = it.avatar,
-                            name = it.name,
-                            tagline = it.tagline,
-                            bio = it.biography,
-                            twitterHandle = it.twitter,
-                        )
-                    }
-                }.map<List<SpeakerUI>, SpeakersScreenUiState>(SpeakersScreenUiState::Success)
+                    it
+                        .map {
+                            SpeakerUI(
+                                id = 1,
+                                imageUrl = it.avatar,
+                                name = it.name,
+                                tagline = it.tagline,
+                                bio = it.biography,
+                                twitterHandle = it.twitter,
+                            )
+                        }.toImmutableList()
+                }.map<ImmutableList<SpeakerUI>, SpeakersScreenUiState>(SpeakersScreenUiState::Success)
                 .onStart {
                     emit(SpeakersScreenUiState.Loading)
                 }.catch {

--- a/presentation/src/main/java/com/android254/presentation/speakers/view/SpeakerComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/speakers/view/SpeakerComponent.kt
@@ -54,8 +54,8 @@ import ke.droidcon.kotlin.presentation.R
 
 @Composable
 fun SpeakerComponent(
-    modifier: Modifier = Modifier,
     speaker: SpeakerUI,
+    modifier: Modifier = Modifier,
     onClick: () -> Unit = {},
 ) {
     Card(

--- a/presentation/src/main/java/com/android254/presentation/speakers/view/SpeakerComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/speakers/view/SpeakerComponent.kt
@@ -169,7 +169,7 @@ fun SpeakerComponent(
 
 @ChaiLightAndDarkComposePreviews
 @Composable
-fun SpeakerComponentPreview() {
+private fun SpeakerComponentPreview() {
     ChaiTheme {
         SpeakerComponent(
             speaker =

--- a/presentation/src/main/java/com/android254/presentation/speakers/view/SpeakerDetailsScreen.kt
+++ b/presentation/src/main/java/com/android254/presentation/speakers/view/SpeakerDetailsScreen.kt
@@ -331,7 +331,7 @@ private fun SpeakerDetailsScreen(
     uiMode = Configuration.UI_MODE_NIGHT_YES,
 )
 @Composable
-fun SpeakerDetailsScreenPreview() {
+private fun SpeakerDetailsScreenPreview() {
     ChaiTheme {
         SpeakerDetailsScreen(
             uiState =

--- a/presentation/src/main/java/com/android254/presentation/speakers/view/SpeakersScreen.kt
+++ b/presentation/src/main/java/com/android254/presentation/speakers/view/SpeakersScreen.kt
@@ -163,7 +163,7 @@ private fun SpeakersScreen(
     uiMode = Configuration.UI_MODE_NIGHT_YES,
 )
 @Composable
-fun SpeakersScreenPreview() {
+private fun SpeakersScreenPreview() {
     ChaiTheme {
         SpeakersScreen(
             uiState = SpeakersScreenUiState.Success(speakers = listOf()),

--- a/presentation/src/main/java/com/android254/presentation/speakers/view/SpeakersScreen.kt
+++ b/presentation/src/main/java/com/android254/presentation/speakers/view/SpeakersScreen.kt
@@ -51,6 +51,7 @@ import com.droidconke.chai.components.ChaiBodyLarge
 import com.droidconke.chai.components.ChaiBodyMediumBold
 import com.droidconke.chai.components.ChaiPullToRefreshBox
 import ke.droidcon.kotlin.presentation.R
+import kotlinx.collections.immutable.persistentListOf
 import ke.droidcon.kotlin.chai.R as ChaiR
 
 @Composable
@@ -166,7 +167,7 @@ private fun SpeakersScreen(
 private fun SpeakersScreenPreview() {
     ChaiTheme {
         SpeakersScreen(
-            uiState = SpeakersScreenUiState.Success(speakers = listOf()),
+            uiState = SpeakersScreenUiState.Success(speakers = persistentListOf()),
         )
     }
 }

--- a/presentation/src/main/java/com/android254/presentation/speakers/view/TopAppBar.kt
+++ b/presentation/src/main/java/com/android254/presentation/speakers/view/TopAppBar.kt
@@ -75,7 +75,7 @@ fun TopAppBar(
 
 @Composable
 @Preview
-fun TopAppBarPreview() {
+private fun TopAppBarPreview() {
     ChaiTheme {
         TopAppBar()
     }

--- a/presentation/src/test/java/com/android254/presentation/common/navigation/FakeEntryProvider.kt
+++ b/presentation/src/test/java/com/android254/presentation/common/navigation/FakeEntryProvider.kt
@@ -52,9 +52,12 @@ fun fakeEntryProvider(): (NavKey) -> NavEntry<NavKey> {
 }
 
 @Composable
-fun FakePlaceholderScreen(screen: Screens) {
+fun FakePlaceholderScreen(
+    screen: Screens,
+    modifier: Modifier = Modifier,
+) {
     Column(
-        modifier = Modifier,
+        modifier = modifier,
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {

--- a/presentation/src/test/java/com/android254/presentation/home/screen/HomeScreenTest.kt
+++ b/presentation/src/test/java/com/android254/presentation/home/screen/HomeScreenTest.kt
@@ -25,6 +25,7 @@ import com.android254.presentation.home.components.HomeSpeakersSection
 import com.android254.presentation.home.components.HomeToolbarComponent
 import com.android254.presentation.models.SponsorPresentationModel
 import com.droidconke.chai.ChaiTheme
+import kotlinx.collections.immutable.persistentListOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -59,7 +60,7 @@ class HomeScreenTest {
     @Test
     fun `Test speakers view is displayed`() {
         composeTestRule.setContent {
-            HomeSpeakersSection(speakers = emptyList())
+            HomeSpeakersSection(speakers = persistentListOf())
         }
 
         composeTestRule.onNodeWithTag("sectionHeader").assertIsDisplayed()
@@ -94,7 +95,7 @@ class HomeScreenTest {
     @Test
     fun `Test sponsors card is displayed`() {
         composeTestRule.setContent {
-            SponsorsCard(sponsors = listOf(SponsorPresentationModel("", "", "", "")))
+            SponsorsCard(sponsors = persistentListOf(SponsorPresentationModel("", "", "", "")))
         }
         composeTestRule.onNodeWithTag("sponsors_section").assertIsDisplayed()
     }
@@ -103,7 +104,7 @@ class HomeScreenTest {
     fun `Test sessions is displayed`() {
         composeTestRule.setContent {
             HomeSessionSection(
-                sessions = emptyList(),
+                sessions = persistentListOf(),
                 onViewAllSessionClicked = {},
                 onSessionClick = {},
             )

--- a/presentation/src/test/java/com/android254/presentation/sessions/view/SessionScreenTest.kt
+++ b/presentation/src/test/java/com/android254/presentation/sessions/view/SessionScreenTest.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.test.onNodeWithText
 import com.android254.presentation.models.EventDate
 import com.android254.presentation.sessions.models.SessionsUiState
 import com.droidconke.chai.ChaiTheme
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
@@ -49,10 +50,10 @@ class SessionScreenTest {
             composeTestRule.setContent {
                 ChaiTheme {
                     SessionsScreen(
-                        sessionsUiState = SessionsUiState(eventDays = listOf(EventDate("16", 1), EventDate("17", 2), EventDate("18", 3))),
+                        sessionsUiState = SessionsUiState(eventDays = persistentListOf(EventDate("16", 1), EventDate("17", 2), EventDate("18", 3))),
                         isRefreshing = true,
                         selectedEventDate = EventDate("16", 1),
-                        currentSelections = emptyList(),
+                        currentSelections = persistentListOf(),
                         navigateToSessionDetails = {},
                         onEvent = {},
                     )
@@ -75,7 +76,7 @@ class SessionScreenTest {
                         sessionsUiState = SessionsUiState(),
                         isRefreshing = true,
                         selectedEventDate = EventDate("16", 1),
-                        currentSelections = emptyList(),
+                        currentSelections = persistentListOf(),
                         navigateToSessionDetails = {},
                         onEvent = {},
                     )

--- a/presentation/stability/presentation-debug.stability
+++ b/presentation/stability/presentation-debug.stability
@@ -38,12 +38,12 @@ public fun com.android254.presentation.about.view.OrganizingTeamComponent(modifi
     - onClickMember: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.about.view.OrganizingTeamSection(modifier: androidx.compose.ui.Modifier, organizingTeam: kotlin.collections.List<com.android254.presentation.models.OrganizingTeamMember>, onClickMember: kotlin.Function1<kotlin.Int, kotlin.Unit>): kotlin.Unit
-  skippable: false
+public fun com.android254.presentation.about.view.OrganizingTeamSection(modifier: androidx.compose.ui.Modifier, organizingTeam: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.OrganizingTeamMember>, onClickMember: kotlin.Function1<kotlin.Int, kotlin.Unit>): kotlin.Unit
+  skippable: true
   restartable: true
   params:
     - modifier: STABLE (marked @Stable or @Immutable)
-    - organizingTeam: RUNTIME (requires runtime check)
+    - organizingTeam: STABLE (known stable type)
     - onClickMember: STABLE (function type)
 
 @Composable
@@ -87,14 +87,14 @@ public fun com.android254.presentation.common.bottomnav.BottomNavItem(isSelected
     - onClick: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.common.bottomnav.BottomNavigationBar(navController: com.android254.presentation.common.navigation.NavigationController, navigationState: com.android254.presentation.common.navigation.NavigationState, currentSessions: kotlin.collections.List<com.android254.presentation.models.SessionPresentationModel>, upNextSessions: kotlin.collections.List<com.android254.presentation.models.SessionPresentationModel>): kotlin.Unit
+public fun com.android254.presentation.common.bottomnav.BottomNavigationBar(navController: com.android254.presentation.common.navigation.NavigationController, navigationState: com.android254.presentation.common.navigation.NavigationState, currentSessions: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionPresentationModel>, upNextSessions: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionPresentationModel>): kotlin.Unit
   skippable: false
   restartable: true
   params:
     - navController: UNSTABLE (has mutable properties or unstable members)
     - navigationState: UNSTABLE (has mutable properties or unstable members)
-    - currentSessions: RUNTIME (requires runtime check)
-    - upNextSessions: RUNTIME (requires runtime check)
+    - currentSessions: STABLE (known stable type)
+    - upNextSessions: STABLE (known stable type)
 
 @Composable
 internal fun com.android254.presentation.common.components.AnimatedModalBottomSheetTransition(visible: kotlin.Boolean, content: @[Composable] @[ExtensionFunctionType] androidx.compose.runtime.internal.ComposableFunction1<androidx.compose.animation.AnimatedVisibilityScope, kotlin.Unit>): kotlin.Unit
@@ -105,19 +105,19 @@ internal fun com.android254.presentation.common.components.AnimatedModalBottomSh
     - content: STABLE (composable function type)
 
 @Composable
-public fun com.android254.presentation.common.components.AnimatedShimmerEffect(gradientColors: kotlin.collections.List<androidx.compose.ui.graphics.Color>, content: @[Composable] androidx.compose.runtime.internal.ComposableFunction1<androidx.compose.ui.graphics.Brush, kotlin.Unit>): kotlin.Unit
-  skippable: false
+public fun com.android254.presentation.common.components.AnimatedShimmerEffect(gradientColors: kotlinx.collections.immutable.ImmutableList<androidx.compose.ui.graphics.Color>, content: @[Composable] androidx.compose.runtime.internal.ComposableFunction1<androidx.compose.ui.graphics.Brush, kotlin.Unit>): kotlin.Unit
+  skippable: true
   restartable: true
   params:
-    - gradientColors: RUNTIME (requires runtime check)
+    - gradientColors: STABLE (known stable type)
     - content: STABLE (composable function type)
 
 @Composable
-private fun com.android254.presentation.common.components.ButtonContent(buttonTexts: kotlin.collections.List<kotlin.String>, index: kotlin.Int, contentColor: androidx.compose.ui.graphics.Color): kotlin.Unit
-  skippable: false
+private fun com.android254.presentation.common.components.ButtonContent(buttonTexts: kotlinx.collections.immutable.ImmutableList<kotlin.String>, index: kotlin.Int, contentColor: androidx.compose.ui.graphics.Color): kotlin.Unit
+  skippable: true
   restartable: true
   params:
-    - buttonTexts: RUNTIME (requires runtime check)
+    - buttonTexts: STABLE (known stable type)
     - index: STABLE (primitive type)
     - contentColor: STABLE (marked @Stable or @Immutable)
 
@@ -213,12 +213,12 @@ public fun com.android254.presentation.common.components.LoadingBox(height: andr
     - color: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.common.components.MultiToggleButton(currentSelections: kotlin.collections.List<com.android254.presentation.models.SessionsFilterOption>, toggleStates: kotlin.collections.List<com.android254.presentation.models.SessionsFilterOption>, modifier: androidx.compose.ui.Modifier, borderSize: androidx.compose.ui.unit.Dp, buttonHeight: androidx.compose.ui.unit.Dp, selectedColor: androidx.compose.ui.graphics.Color, enabled: kotlin.Boolean, onClick: kotlin.Function1<com.android254.presentation.models.SessionsFilterOption, kotlin.Unit>): kotlin.Unit
-  skippable: false
+public fun com.android254.presentation.common.components.MultiToggleButton(currentSelections: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionsFilterOption>, toggleStates: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionsFilterOption>, modifier: androidx.compose.ui.Modifier, borderSize: androidx.compose.ui.unit.Dp, buttonHeight: androidx.compose.ui.unit.Dp, selectedColor: androidx.compose.ui.graphics.Color, enabled: kotlin.Boolean, onClick: kotlin.Function1<com.android254.presentation.models.SessionsFilterOption, kotlin.Unit>): kotlin.Unit
+  skippable: true
   restartable: true
   params:
-    - currentSelections: RUNTIME (requires runtime check)
-    - toggleStates: RUNTIME (requires runtime check)
+    - currentSelections: STABLE (known stable type)
+    - toggleStates: STABLE (known stable type)
     - modifier: STABLE (marked @Stable or @Immutable)
     - borderSize: STABLE (marked @Stable or @Immutable)
     - buttonHeight: STABLE (marked @Stable or @Immutable)
@@ -234,19 +234,19 @@ private fun com.android254.presentation.common.components.NowIndicator(accentCol
     - accentColor: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.common.components.OrganizedBySection(modifier: androidx.compose.ui.Modifier, organizationLogos: kotlin.collections.List<kotlin.String>): kotlin.Unit
-  skippable: false
+public fun com.android254.presentation.common.components.OrganizedBySection(modifier: androidx.compose.ui.Modifier, organizationLogos: kotlinx.collections.immutable.ImmutableList<kotlin.String>): kotlin.Unit
+  skippable: true
   restartable: true
   params:
     - modifier: STABLE (marked @Stable or @Immutable)
-    - organizationLogos: RUNTIME (requires runtime check)
+    - organizationLogos: STABLE (known stable type)
 
 @Composable
 public fun com.android254.presentation.common.components.SessionDetails(session: com.android254.presentation.models.SessionPresentationModel, onBookMark: kotlin.Function1<kotlin.String, kotlin.Unit>): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - session: RUNTIME (requires runtime check)
+    - session: STABLE (class with no mutable properties)
     - onBookMark: STABLE (function type)
 
 @Composable
@@ -266,19 +266,19 @@ public fun com.android254.presentation.common.components.SessionTimeComponent(se
 
 @Composable
 public fun com.android254.presentation.common.components.SessionTitleComponent(session: com.android254.presentation.models.SessionPresentationModel, onBookmark: kotlin.Function1<kotlin.String, kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - session: RUNTIME (requires runtime check)
+    - session: STABLE (class with no mutable properties)
     - onBookmark: STABLE (function type)
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.android254.presentation.common.components.SessionsCard(session: com.android254.presentation.models.SessionPresentationModel, navigateToSessionDetails: kotlin.Function1<@[ParameterName(name = \, onBookmark: kotlin.Function1<kotlin.String, kotlin.Unit>): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - session: RUNTIME (requires runtime check)
+    - session: STABLE (class with no mutable properties)
     - navigateToSessionDetails: STABLE (function type)
     - onBookmark: STABLE (function type)
 
@@ -290,33 +290,33 @@ public fun com.android254.presentation.common.components.SessionsDescriptionComp
     - sessionDescription: STABLE (String is immutable)
 
 @Composable
-public fun com.android254.presentation.common.components.SponsorsCard(modifier: androidx.compose.ui.Modifier, sponsors: kotlin.collections.List<com.android254.presentation.models.SponsorPresentationModel>): kotlin.Unit
-  skippable: false
+public fun com.android254.presentation.common.components.SponsorsCard(modifier: androidx.compose.ui.Modifier, sponsors: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SponsorPresentationModel>): kotlin.Unit
+  skippable: true
   restartable: true
   params:
     - modifier: STABLE (marked @Stable or @Immutable)
-    - sponsors: RUNTIME (requires runtime check)
+    - sponsors: STABLE (known stable type)
 
 @Composable
-private fun com.android254.presentation.common.components.TextContent(buttonTexts: kotlin.collections.List<kotlin.String>, index: kotlin.Int, contentColor: androidx.compose.ui.graphics.Color, modifier: androidx.compose.ui.Modifier): kotlin.Unit
-  skippable: false
+private fun com.android254.presentation.common.components.TextContent(buttonTexts: kotlinx.collections.immutable.ImmutableList<kotlin.String>, index: kotlin.Int, contentColor: androidx.compose.ui.graphics.Color, modifier: androidx.compose.ui.Modifier): kotlin.Unit
+  skippable: true
   restartable: true
   params:
-    - buttonTexts: RUNTIME (requires runtime check)
+    - buttonTexts: STABLE (known stable type)
     - index: STABLE (primitive type)
     - contentColor: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.android254.presentation.common.components.TimeAndVenueComponent(session: com.android254.presentation.models.SessionPresentationModel): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - session: RUNTIME (requires runtime check)
+    - session: STABLE (class with no mutable properties)
 
 @Composable
-private fun com.android254.presentation.common.components.ToggleButton(buttonShape: androidx.compose.foundation.shape.CornerBasedShape, border: androidx.compose.foundation.BorderStroke, backgroundColor: androidx.compose.ui.graphics.Color, elevation: androidx.compose.material3.ButtonElevation, enabled: kotlin.Boolean, buttonTexts: kotlin.collections.List<kotlin.String>, index: kotlin.Int, contentColor: androidx.compose.ui.graphics.Color, modifier: androidx.compose.ui.Modifier, onClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
-  skippable: false
+private fun com.android254.presentation.common.components.ToggleButton(buttonShape: androidx.compose.foundation.shape.CornerBasedShape, border: androidx.compose.foundation.BorderStroke, backgroundColor: androidx.compose.ui.graphics.Color, elevation: androidx.compose.material3.ButtonElevation, enabled: kotlin.Boolean, buttonTexts: kotlinx.collections.immutable.ImmutableList<kotlin.String>, index: kotlin.Int, contentColor: androidx.compose.ui.graphics.Color, modifier: androidx.compose.ui.Modifier, onClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+  skippable: true
   restartable: true
   params:
     - buttonShape: STABLE (known stable type)
@@ -324,7 +324,7 @@ private fun com.android254.presentation.common.components.ToggleButton(buttonSha
     - backgroundColor: STABLE (marked @Stable or @Immutable)
     - elevation: STABLE (marked @Stable or @Immutable)
     - enabled: STABLE (primitive type)
-    - buttonTexts: RUNTIME (requires runtime check)
+    - buttonTexts: STABLE (known stable type)
     - index: STABLE (primitive type)
     - contentColor: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
@@ -358,12 +358,12 @@ public fun com.android254.presentation.common.navigation.droidconEntryProvider(u
     - onActionClicked: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.common.navigation.rememberNavigationState(startRoute: androidx.navigation3.runtime.NavKey, topLevelRoutes: kotlin.collections.Set<androidx.navigation3.runtime.NavKey>): com.android254.presentation.common.navigation.NavigationState
+public fun com.android254.presentation.common.navigation.rememberNavigationState(startRoute: androidx.navigation3.runtime.NavKey, topLevelRoutes: kotlinx.collections.immutable.ImmutableSet<androidx.navigation3.runtime.NavKey>): com.android254.presentation.common.navigation.NavigationState
   skippable: false
   restartable: false
   params:
     - startRoute: UNKNOWN (interface or non-final class; concrete implementation unknown)
-    - topLevelRoutes: RUNTIME (requires runtime check)
+    - topLevelRoutes: STABLE (known stable type)
 
 @Composable
 private fun com.android254.presentation.common.navigation.sessionModel(key: com.android254.presentation.common.navigation.Screens.SessionDetails, viewModel: com.android254.presentation.sessionDetails.SessionDetailsViewModel): com.android254.presentation.sessionDetails.SessionDetailsViewModel
@@ -509,10 +509,10 @@ public fun com.android254.presentation.home.components.HomeSectionHeaderComponen
 
 @Composable
 public fun com.android254.presentation.home.components.HomeSessionContent(session: com.android254.presentation.models.SessionPresentationModel, onSessionClick: kotlin.Function1<@[ParameterName(name = \, modifier: androidx.compose.ui.Modifier): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - session: RUNTIME (requires runtime check)
+    - session: STABLE (class with no mutable properties)
     - onSessionClick: STABLE (function type)
     - modifier: STABLE (marked @Stable or @Immutable)
 
@@ -529,12 +529,12 @@ public fun com.android254.presentation.home.components.HomeSessionLoadingItem():
   params:
 
 @Composable
-public fun com.android254.presentation.home.components.HomeSessionSection(modifier: androidx.compose.ui.Modifier, sessions: kotlin.collections.List<com.android254.presentation.models.SessionPresentationModel>, onSessionClick: kotlin.Function1<@[ParameterName(name = \, onViewAllSessionClicked: kotlin.Function0<kotlin.Unit>): kotlin.Unit
-  skippable: false
+public fun com.android254.presentation.home.components.HomeSessionSection(modifier: androidx.compose.ui.Modifier, sessions: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionPresentationModel>, onSessionClick: kotlin.Function1<@[ParameterName(name = \, onViewAllSessionClicked: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+  skippable: true
   restartable: true
   params:
     - modifier: STABLE (marked @Stable or @Immutable)
-    - sessions: RUNTIME (requires runtime check)
+    - sessions: STABLE (known stable type)
     - onSessionClick: STABLE (function type)
     - onViewAllSessionClicked: STABLE (function type)
 
@@ -565,11 +565,11 @@ public fun com.android254.presentation.home.components.HomeSpeakersLoadingItem()
   params:
 
 @Composable
-public fun com.android254.presentation.home.components.HomeSpeakersSection(speakers: kotlin.collections.List<com.android254.presentation.models.SpeakerUI>, navigateToSpeakers: kotlin.Function0<kotlin.Unit>, navigateToSpeaker: kotlin.Function1<kotlin.String, kotlin.Unit>): kotlin.Unit
-  skippable: false
+public fun com.android254.presentation.home.components.HomeSpeakersSection(speakers: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SpeakerUI>, navigateToSpeakers: kotlin.Function0<kotlin.Unit>, navigateToSpeaker: kotlin.Function1<kotlin.String, kotlin.Unit>): kotlin.Unit
+  skippable: true
   restartable: true
   params:
-    - speakers: RUNTIME (requires runtime check)
+    - speakers: STABLE (known stable type)
     - navigateToSpeakers: STABLE (function type)
     - navigateToSpeaker: STABLE (function type)
 
@@ -695,10 +695,10 @@ public fun com.android254.presentation.sessionDetails.view.components.TopBar(onN
 
 @Composable
 public fun com.android254.presentation.sessions.components.CurrentSessionComponent(session: com.android254.presentation.models.SessionPresentationModel, modifier: androidx.compose.ui.Modifier, onClicked: kotlin.Function1<kotlin.String, kotlin.Unit>): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - session: RUNTIME (requires runtime check)
+    - session: STABLE (class with no mutable properties)
     - modifier: STABLE (marked @Stable or @Immutable)
     - onClicked: STABLE (function type)
 
@@ -715,13 +715,13 @@ public fun com.android254.presentation.sessions.components.CustomSwitch(width: a
     - onCheckedChange: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.sessions.components.EventDaySelector(selectedDate: com.android254.presentation.models.EventDate, updateSelectedDay: kotlin.Function1<com.android254.presentation.models.EventDate, kotlin.Unit>, eventDates: kotlin.collections.List<com.android254.presentation.models.EventDate>): kotlin.Unit
-  skippable: false
+public fun com.android254.presentation.sessions.components.EventDaySelector(selectedDate: com.android254.presentation.models.EventDate, updateSelectedDay: kotlin.Function1<com.android254.presentation.models.EventDate, kotlin.Unit>, eventDates: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.EventDate>): kotlin.Unit
+  skippable: true
   restartable: true
   params:
     - selectedDate: STABLE (class with no mutable properties)
     - updateSelectedDay: STABLE (function type)
-    - eventDates: RUNTIME (requires runtime check)
+    - eventDates: STABLE (known stable type)
 
 @Composable
 public fun com.android254.presentation.sessions.components.EventDaySelectorButton(title: kotlin.String, subtitle: kotlin.String, selected: kotlin.Boolean, onClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
@@ -734,13 +734,13 @@ public fun com.android254.presentation.sessions.components.EventDaySelectorButto
     - onClick: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.sessions.components.SessionListComponent(isRefreshing: kotlin.Boolean, pullToRefreshState: androidx.compose.material3.pulltorefresh.PullToRefreshState, sessions: kotlin.collections.List<com.android254.presentation.models.SessionPresentationModel>, sessionScreenState: com.android254.presentation.sessions.view.SessionScreenState, isSessionLayoutList: kotlin.Boolean, navigateToSessionDetails: kotlin.Function1<@[ParameterName(name = \, onEvent: kotlin.Function1<com.android254.presentation.sessions.models.SessionsIntentHandler, kotlin.Unit>): kotlin.Unit
-  skippable: false
+public fun com.android254.presentation.sessions.components.SessionListComponent(isRefreshing: kotlin.Boolean, pullToRefreshState: androidx.compose.material3.pulltorefresh.PullToRefreshState, sessions: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionPresentationModel>, sessionScreenState: com.android254.presentation.sessions.view.SessionScreenState, isSessionLayoutList: kotlin.Boolean, navigateToSessionDetails: kotlin.Function1<@[ParameterName(name = \, onEvent: kotlin.Function1<com.android254.presentation.sessions.models.SessionsIntentHandler, kotlin.Unit>): kotlin.Unit
+  skippable: true
   restartable: true
   params:
     - isRefreshing: STABLE (primitive type)
     - pullToRefreshState: STABLE (marked @Stable or @Immutable)
-    - sessions: RUNTIME (requires runtime check)
+    - sessions: STABLE (known stable type)
     - sessionScreenState: STABLE (class with no mutable properties)
     - isSessionLayoutList: STABLE (primitive type)
     - navigateToSessionDetails: STABLE (function type)
@@ -758,7 +758,7 @@ public fun com.android254.presentation.sessions.components.SessionsCardWithBanne
   restartable: true
   params:
     - modifier: STABLE (marked @Stable or @Immutable)
-    - session: RUNTIME (requires runtime check)
+    - session: STABLE (class with no mutable properties)
     - navigateToSessionDetails: STABLE (function type)
     - viewModel: RUNTIME (requires runtime check)
 
@@ -771,13 +771,13 @@ public fun com.android254.presentation.sessions.components.SessionsErrorComponen
     - retry: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.sessions.components.SessionsFilterPanel(onDismiss: kotlin.Function0<kotlin.Unit>, selectableFilters: kotlin.collections.List<com.android254.presentation.models.SessionsFilterOption>, currentSelections: kotlin.collections.List<com.android254.presentation.models.SessionsFilterOption>, updateSelectedFilterOptionList: kotlin.Function1<com.android254.presentation.models.SessionsFilterOption, kotlin.Unit>, clearSelectedFilterList: kotlin.Function0<kotlin.Unit>): kotlin.Unit
-  skippable: false
+public fun com.android254.presentation.sessions.components.SessionsFilterPanel(onDismiss: kotlin.Function0<kotlin.Unit>, selectableFilters: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionsFilterOption>, currentSelections: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionsFilterOption>, updateSelectedFilterOptionList: kotlin.Function1<com.android254.presentation.models.SessionsFilterOption, kotlin.Unit>, clearSelectedFilterList: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+  skippable: true
   restartable: true
   params:
     - onDismiss: STABLE (function type)
-    - selectableFilters: RUNTIME (requires runtime check)
-    - currentSelections: RUNTIME (requires runtime check)
+    - selectableFilters: STABLE (known stable type)
+    - currentSelections: STABLE (known stable type)
     - updateSelectedFilterOptionList: STABLE (function type)
     - clearSelectedFilterList: STABLE (function type)
 
@@ -789,10 +789,10 @@ public fun com.android254.presentation.sessions.components.SessionsLoadingCard()
 
 @Composable
 public fun com.android254.presentation.sessions.components.SessionsStateComponent(sessionsUiState: com.android254.presentation.sessions.models.SessionsUiState, navigateToSessionDetails: kotlin.Function1<@[ParameterName(name = \, isRefreshing: kotlin.Boolean, sessionScreenState: com.android254.presentation.sessions.view.SessionScreenState, isSessionLayoutList: kotlin.Boolean, onEvent: kotlin.Function1<com.android254.presentation.sessions.models.SessionsIntentHandler, kotlin.Unit>): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - sessionsUiState: RUNTIME (requires runtime check)
+    - sessionsUiState: STABLE (class with no mutable properties)
     - navigateToSessionDetails: STABLE (function type)
     - isRefreshing: STABLE (primitive type)
     - sessionScreenState: STABLE (class with no mutable properties)
@@ -800,13 +800,13 @@ public fun com.android254.presentation.sessions.components.SessionsStateComponen
     - onEvent: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.sessions.components.SpeakerDetailsAndLikeButtonComponent(onBookmarkClicked: kotlin.Function0<kotlin.Unit>, isSessionStarred: kotlin.Boolean, speakers: kotlin.collections.List<com.android254.presentation.models.SessionSpeakersPresentationModel>): kotlin.Unit
-  skippable: false
+public fun com.android254.presentation.sessions.components.SpeakerDetailsAndLikeButtonComponent(onBookmarkClicked: kotlin.Function0<kotlin.Unit>, isSessionStarred: kotlin.Boolean, speakers: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionSpeakersPresentationModel>): kotlin.Unit
+  skippable: true
   restartable: true
   params:
     - onBookmarkClicked: STABLE (function type)
     - isSessionStarred: STABLE (primitive type)
-    - speakers: RUNTIME (requires runtime check)
+    - speakers: STABLE (known stable type)
 
 @Composable
 private fun com.android254.presentation.sessions.components.animateAlignmentAsState(targetBiasValue: kotlin.Float): androidx.compose.runtime.State<androidx.compose.ui.BiasAlignment>
@@ -824,14 +824,14 @@ public fun com.android254.presentation.sessions.view.SessionsRoute(sessionsViewM
     - navigateToSessionDetails: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.sessions.view.SessionsScreen(sessionsUiState: com.android254.presentation.sessions.models.SessionsUiState, selectedEventDate: com.android254.presentation.models.EventDate, isRefreshing: kotlin.Boolean, currentSelections: kotlin.collections.List<com.android254.presentation.models.SessionsFilterOption>, navigateToSessionDetails: kotlin.Function1<@[ParameterName(name = \, onEvent: kotlin.Function1<com.android254.presentation.sessions.models.SessionsIntentHandler, kotlin.Unit>): kotlin.Unit
-  skippable: false
+public fun com.android254.presentation.sessions.view.SessionsScreen(sessionsUiState: com.android254.presentation.sessions.models.SessionsUiState, selectedEventDate: com.android254.presentation.models.EventDate, isRefreshing: kotlin.Boolean, currentSelections: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionsFilterOption>, navigateToSessionDetails: kotlin.Function1<@[ParameterName(name = \, onEvent: kotlin.Function1<com.android254.presentation.sessions.models.SessionsIntentHandler, kotlin.Unit>): kotlin.Unit
+  skippable: true
   restartable: true
   params:
-    - sessionsUiState: RUNTIME (requires runtime check)
+    - sessionsUiState: STABLE (class with no mutable properties)
     - selectedEventDate: STABLE (class with no mutable properties)
     - isRefreshing: STABLE (primitive type)
-    - currentSelections: RUNTIME (requires runtime check)
+    - currentSelections: STABLE (known stable type)
     - navigateToSessionDetails: STABLE (function type)
     - onEvent: STABLE (function type)
 

--- a/presentation/stability/presentation-debug.stability
+++ b/presentation/stability/presentation-debug.stability
@@ -5,12 +5,12 @@
 //   ./gradlew :presentation:stabilityDump
 
 @Composable
-public fun com.android254.presentation.about.view.AboutDroidconSection(modifier: androidx.compose.ui.Modifier, droidconDesc: kotlin.String): kotlin.Unit
+public fun com.android254.presentation.about.view.AboutDroidconSection(droidconDesc: kotlin.String, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - droidconDesc: STABLE (String is immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.android254.presentation.about.view.AboutRoute(aboutViewModel: com.android254.presentation.about.view.AboutViewModel, navigateToFeedbackScreen: kotlin.Function0<kotlin.Unit>): kotlin.Unit
@@ -29,28 +29,29 @@ private fun com.android254.presentation.about.view.AboutScreen(uiState: com.andr
     - navigateToFeedbackScreen: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.about.view.OrganizingTeamComponent(modifier: androidx.compose.ui.Modifier, teamMember: com.android254.presentation.models.OrganizingTeamMember, onClickMember: kotlin.Function1<kotlin.Int, kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.about.view.OrganizingTeamComponent(teamMember: com.android254.presentation.models.OrganizingTeamMember, modifier: androidx.compose.ui.Modifier, onClickMember: kotlin.Function1<kotlin.Int, kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - teamMember: STABLE (class with no mutable properties)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - onClickMember: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.about.view.OrganizingTeamSection(modifier: androidx.compose.ui.Modifier, organizingTeam: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.OrganizingTeamMember>, onClickMember: kotlin.Function1<kotlin.Int, kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.about.view.OrganizingTeamSection(organizingTeam: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.OrganizingTeamMember>, modifier: androidx.compose.ui.Modifier, onClickMember: kotlin.Function1<kotlin.Int, kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - organizingTeam: STABLE (known stable type)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - onClickMember: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.activity.MainScreen(viewModel: com.android254.presentation.activity.MainViewModel, authViewModel: com.android254.presentation.auth.AuthViewModel): kotlin.Unit
+public fun com.android254.presentation.activity.MainScreen(modifier: androidx.compose.ui.Modifier, viewModel: com.android254.presentation.activity.MainViewModel, authViewModel: com.android254.presentation.auth.AuthViewModel): kotlin.Unit
   skippable: false
   restartable: true
   params:
+    - modifier: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
     - authViewModel: RUNTIME (requires runtime check)
 
@@ -78,21 +79,23 @@ public fun com.android254.presentation.auth.view.GoogleSignInButton(text: kotlin
     - onClick: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.common.bottomnav.BottomNavItem(isSelected: kotlin.Boolean, destination: com.android254.presentation.common.navigation.TopLevelDestination, onClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.common.bottomnav.BottomNavItem(isSelected: kotlin.Boolean, destination: com.android254.presentation.common.navigation.TopLevelDestination, onClick: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - isSelected: STABLE (primitive type)
     - destination: STABLE (class with no mutable properties)
     - onClick: STABLE (function type)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.common.bottomnav.BottomNavigationBar(navController: com.android254.presentation.common.navigation.NavigationController, navigationState: com.android254.presentation.common.navigation.NavigationState, currentSessions: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionPresentationModel>, upNextSessions: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionPresentationModel>): kotlin.Unit
+public fun com.android254.presentation.common.bottomnav.BottomNavigationBar(navController: com.android254.presentation.common.navigation.NavigationController, navigationState: com.android254.presentation.common.navigation.NavigationState, modifier: androidx.compose.ui.Modifier, currentSessions: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionPresentationModel>, upNextSessions: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionPresentationModel>): kotlin.Unit
   skippable: false
   restartable: true
   params:
     - navController: UNSTABLE (has mutable properties or unstable members)
     - navigationState: UNSTABLE (has mutable properties or unstable members)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - currentSessions: STABLE (known stable type)
     - upNextSessions: STABLE (known stable type)
 
@@ -122,11 +125,12 @@ private fun com.android254.presentation.common.components.ButtonContent(buttonTe
     - contentColor: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.common.components.DroidConTextField(label: kotlin.String): kotlin.Unit
+public fun com.android254.presentation.common.components.DroidConTextField(label: kotlin.String, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - label: STABLE (String is immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.android254.presentation.common.components.DroidconAppBar(modifier: androidx.compose.ui.Modifier, onActionClicked: kotlin.Function0<kotlin.Unit>): kotlin.Unit
@@ -137,24 +141,24 @@ public fun com.android254.presentation.common.components.DroidconAppBar(modifier
     - onActionClicked: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.common.components.DroidconAppBarWithFeedbackButton(modifier: androidx.compose.ui.Modifier, onButtonClick: kotlin.Function0<kotlin.Unit>, userProfile: kotlin.String): kotlin.Unit
+public fun com.android254.presentation.common.components.DroidconAppBarWithFeedbackButton(onButtonClick: kotlin.Function0<kotlin.Unit>, userProfile: kotlin.String, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - onButtonClick: STABLE (function type)
     - userProfile: STABLE (String is immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.common.components.DroidconAppBarWithFilter(modifier: androidx.compose.ui.Modifier, isListActive: kotlin.Boolean, onListIconClick: kotlin.Function0<kotlin.Unit>, onAgendaIconClick: kotlin.Function0<kotlin.Unit>, isFilterActive: kotlin.Boolean, onFilterButtonClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.common.components.DroidconAppBarWithFilter(isListActive: kotlin.Boolean, onListIconClick: kotlin.Function0<kotlin.Unit>, onAgendaIconClick: kotlin.Function0<kotlin.Unit>, isFilterActive: kotlin.Boolean, modifier: androidx.compose.ui.Modifier, onFilterButtonClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - isListActive: STABLE (primitive type)
     - onListIconClick: STABLE (function type)
     - onAgendaIconClick: STABLE (function type)
     - isFilterActive: STABLE (primitive type)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - onFilterButtonClick: STABLE (function type)
 
 @Composable
@@ -166,46 +170,49 @@ public fun com.android254.presentation.common.components.FeedbackButton(modifier
     - onButtonClick: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.common.components.FilterButton(modifier: androidx.compose.ui.Modifier, isActive: kotlin.Boolean, onButtonClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.common.components.FilterButton(isActive: kotlin.Boolean, modifier: androidx.compose.ui.Modifier, onButtonClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - isActive: STABLE (primitive type)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - onButtonClick: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.common.components.FullscreenDialog(onDismissRequest: kotlin.Function0<kotlin.Unit>, dismissOnBackPress: kotlin.Boolean, content: @[Composable] androidx.compose.runtime.internal.ComposableFunction1<com.android254.presentation.common.components.ModalTransitionDialogHelper, kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.common.components.FullscreenDialog(onDismissRequest: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier, dismissOnBackPress: kotlin.Boolean, content: @[Composable] androidx.compose.runtime.internal.ComposableFunction1<com.android254.presentation.common.components.ModalTransitionDialogHelper, kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - onDismissRequest: STABLE (function type)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - dismissOnBackPress: STABLE (primitive type)
     - content: STABLE (composable function type)
 
 @Composable
-public fun com.android254.presentation.common.components.LayoutIconButtons(modifier: androidx.compose.ui.Modifier, isListActive: kotlin.Boolean, onListIconClick: kotlin.Function0<kotlin.Unit>, onAgendaIconClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.common.components.LayoutIconButtons(isListActive: kotlin.Boolean, onListIconClick: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier, onAgendaIconClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - isListActive: STABLE (primitive type)
+    - onListIconClick: STABLE (function type)
+    - modifier: STABLE (marked @Stable or @Immutable)
+    - onAgendaIconClick: STABLE (function type)
+
+@Composable
+public fun com.android254.presentation.common.components.Loader(modifier: androidx.compose.ui.Modifier, message: kotlin.String): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - modifier: STABLE (marked @Stable or @Immutable)
-    - isListActive: STABLE (primitive type)
-    - onListIconClick: STABLE (function type)
-    - onAgendaIconClick: STABLE (function type)
-
-@Composable
-public fun com.android254.presentation.common.components.Loader(message: kotlin.String): kotlin.Unit
-  skippable: true
-  restartable: true
-  params:
     - message: STABLE (String is immutable)
 
 @Composable
-public fun com.android254.presentation.common.components.LoadingBox(height: androidx.compose.ui.unit.Dp, width: androidx.compose.ui.unit.Dp, widthRatio: kotlin.Float?, cornerRadius: androidx.compose.ui.unit.Dp, brush: androidx.compose.ui.graphics.Brush?, color: androidx.compose.ui.graphics.Color): kotlin.Unit
+public fun com.android254.presentation.common.components.LoadingBox(height: androidx.compose.ui.unit.Dp, modifier: androidx.compose.ui.Modifier, width: androidx.compose.ui.unit.Dp, widthRatio: kotlin.Float?, cornerRadius: androidx.compose.ui.unit.Dp, brush: androidx.compose.ui.graphics.Brush?, color: androidx.compose.ui.graphics.Color): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - height: STABLE (marked @Stable or @Immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - width: STABLE (marked @Stable or @Immutable)
     - widthRatio: STABLE (class with no mutable properties)
     - cornerRadius: STABLE (marked @Stable or @Immutable)
@@ -234,35 +241,38 @@ private fun com.android254.presentation.common.components.NowIndicator(accentCol
     - accentColor: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.common.components.OrganizedBySection(modifier: androidx.compose.ui.Modifier, organizationLogos: kotlinx.collections.immutable.ImmutableList<kotlin.String>): kotlin.Unit
+public fun com.android254.presentation.common.components.OrganizedBySection(organizationLogos: kotlinx.collections.immutable.ImmutableList<kotlin.String>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - organizationLogos: STABLE (known stable type)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.common.components.SessionDetails(session: com.android254.presentation.models.SessionPresentationModel, onBookMark: kotlin.Function1<kotlin.String, kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.common.components.SessionDetails(session: com.android254.presentation.models.SessionPresentationModel, onBookMark: kotlin.Function1<kotlin.String, kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - session: STABLE (class with no mutable properties)
     - onBookMark: STABLE (function type)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.common.components.SessionPresenterComponents(speaker: com.android254.presentation.models.SessionSpeakersPresentationModel): kotlin.Unit
+public fun com.android254.presentation.common.components.SessionPresenterComponents(speaker: com.android254.presentation.models.SessionSpeakersPresentationModel, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - speaker: STABLE (class with no mutable properties)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.common.components.SessionTimeComponent(sessionStartTime: kotlin.String, sessionAmOrPm: kotlin.String): kotlin.Unit
+public fun com.android254.presentation.common.components.SessionTimeComponent(sessionStartTime: kotlin.String, sessionAmOrPm: kotlin.String, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - sessionStartTime: STABLE (String is immutable)
     - sessionAmOrPm: STABLE (String is immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.android254.presentation.common.components.SessionTitleComponent(session: com.android254.presentation.models.SessionPresentationModel, onBookmark: kotlin.Function1<kotlin.String, kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
@@ -274,13 +284,14 @@ public fun com.android254.presentation.common.components.SessionTitleComponent(s
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.common.components.SessionsCard(session: com.android254.presentation.models.SessionPresentationModel, navigateToSessionDetails: kotlin.Function1<@[ParameterName(name = \, onBookmark: kotlin.Function1<kotlin.String, kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.common.components.SessionsCard(session: com.android254.presentation.models.SessionPresentationModel, navigateToSessionDetails: kotlin.Function1<@[ParameterName(name = \, onBookmark: kotlin.Function1<kotlin.String, kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - session: STABLE (class with no mutable properties)
     - navigateToSessionDetails: STABLE (function type)
     - onBookmark: STABLE (function type)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.android254.presentation.common.components.SessionsDescriptionComponent(sessionDescription: kotlin.String): kotlin.Unit
@@ -290,12 +301,12 @@ public fun com.android254.presentation.common.components.SessionsDescriptionComp
     - sessionDescription: STABLE (String is immutable)
 
 @Composable
-public fun com.android254.presentation.common.components.SponsorsCard(modifier: androidx.compose.ui.Modifier, sponsors: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SponsorPresentationModel>): kotlin.Unit
+public fun com.android254.presentation.common.components.SponsorsCard(sponsors: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SponsorPresentationModel>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - sponsors: STABLE (known stable type)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
 private fun com.android254.presentation.common.components.TextContent(buttonTexts: kotlinx.collections.immutable.ImmutableList<kotlin.String>, index: kotlin.Int, contentColor: androidx.compose.ui.graphics.Color, modifier: androidx.compose.ui.Modifier): kotlin.Unit
@@ -308,11 +319,12 @@ private fun com.android254.presentation.common.components.TextContent(buttonText
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.common.components.TimeAndVenueComponent(session: com.android254.presentation.models.SessionPresentationModel): kotlin.Unit
+public fun com.android254.presentation.common.components.TimeAndVenueComponent(session: com.android254.presentation.models.SessionPresentationModel, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - session: STABLE (class with no mutable properties)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
 private fun com.android254.presentation.common.components.ToggleButton(buttonShape: androidx.compose.foundation.shape.CornerBasedShape, border: androidx.compose.foundation.BorderStroke, backgroundColor: androidx.compose.ui.graphics.Color, elevation: androidx.compose.material3.ButtonElevation, enabled: kotlin.Boolean, buttonTexts: kotlinx.collections.immutable.ImmutableList<kotlin.String>, index: kotlin.Int, contentColor: androidx.compose.ui.graphics.Color, modifier: androidx.compose.ui.Modifier, onClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
@@ -331,20 +343,21 @@ private fun com.android254.presentation.common.components.ToggleButton(buttonSha
     - onClick: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.common.divider.CustomDivider(): kotlin.Unit
+public fun com.android254.presentation.common.divider.CustomDivider(modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.common.navigation.Navigation(modifier: androidx.compose.ui.Modifier, navController: com.android254.presentation.common.navigation.NavigationController, navigationState: com.android254.presentation.common.navigation.NavigationState, updateBottomBarState: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onActionClicked: kotlin.Function0<kotlin.Unit>, entryProvider: kotlin.Function1<androidx.navigation3.runtime.NavKey, androidx.navigation3.runtime.NavEntry<androidx.navigation3.runtime.NavKey>>): kotlin.Unit
+public fun com.android254.presentation.common.navigation.Navigation(navController: com.android254.presentation.common.navigation.NavigationController, navigationState: com.android254.presentation.common.navigation.NavigationState, updateBottomBarState: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, modifier: androidx.compose.ui.Modifier, onActionClicked: kotlin.Function0<kotlin.Unit>, entryProvider: kotlin.Function1<androidx.navigation3.runtime.NavKey, androidx.navigation3.runtime.NavEntry<androidx.navigation3.runtime.NavKey>>): kotlin.Unit
   skippable: false
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - navController: UNSTABLE (has mutable properties or unstable members)
     - navigationState: UNSTABLE (has mutable properties or unstable members)
     - updateBottomBarState: STABLE (function type)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - onActionClicked: STABLE (function type)
     - entryProvider: STABLE (function type)
 
@@ -381,14 +394,14 @@ public fun com.android254.presentation.common.navigation.toEntries(entryProvider
     - entryProvider: STABLE (function type)
 
 @Composable
-private fun com.android254.presentation.common.stepper.IconBox(modifier: androidx.compose.ui.Modifier, icon: androidx.compose.ui.graphics.vector.ImageVector, accentColor: androidx.compose.ui.graphics.Color, sizeInt: kotlin.Int, intensity: com.android254.presentation.common.stepper.Intensity): kotlin.Unit
+private fun com.android254.presentation.common.stepper.IconBox(icon: androidx.compose.ui.graphics.vector.ImageVector, accentColor: androidx.compose.ui.graphics.Color, sizeInt: kotlin.Int, modifier: androidx.compose.ui.Modifier, intensity: com.android254.presentation.common.stepper.Intensity): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - icon: STABLE (marked @Stable or @Immutable)
     - accentColor: STABLE (marked @Stable or @Immutable)
     - sizeInt: STABLE (primitive type)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - intensity: STABLE (class with no mutable properties)
 
 @Composable
@@ -414,10 +427,11 @@ public fun com.android254.presentation.feed.view.FeedComponent(feed: com.android
     - onClickItem: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.feed.view.FeedLoadingComponent(): kotlin.Unit
+public fun com.android254.presentation.feed.view.FeedLoadingComponent(modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.android254.presentation.feed.view.FeedRoute(feedViewModel: com.android254.presentation.feed.FeedViewModel, navigateToFeedbackScreen: kotlin.Function0<kotlin.Unit>): kotlin.Unit
@@ -436,19 +450,21 @@ private fun com.android254.presentation.feed.view.FeedScreen(feedUIState: com.an
     - navigateToFeedbackScreen: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.feed.view.FeedShareSection(onCancelClicked: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.feed.view.FeedShareSection(modifier: androidx.compose.ui.Modifier, onCancelClicked: kotlin.Function0<kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
   params:
+    - modifier: STABLE (marked @Stable or @Immutable)
     - onCancelClicked: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.feed.view.PlatformButton(platform: kotlin.String, icon: kotlin.Int): kotlin.Unit
+public fun com.android254.presentation.feed.view.PlatformButton(platform: kotlin.String, icon: kotlin.Int, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - platform: STABLE (String is immutable)
     - icon: STABLE (primitive type)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.android254.presentation.feedback.view.FeedBackRoute(darkTheme: kotlin.Boolean, navigateBack: kotlin.Function0<kotlin.Unit>): kotlin.Unit
@@ -467,10 +483,11 @@ private fun com.android254.presentation.feedback.view.FeedBackScreen(darkTheme: 
     - navigateBack: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.feedback.view.FeedbackTitle(): kotlin.Unit
+public fun com.android254.presentation.feedback.view.FeedbackTitle(modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.android254.presentation.home.components.HomeBannerSection(homeViewState: com.android254.presentation.home.viewstate.HomeViewState): kotlin.Unit
@@ -480,22 +497,25 @@ public fun com.android254.presentation.home.components.HomeBannerSection(homeVie
     - homeViewState: RUNTIME (requires runtime check)
 
 @Composable
-public fun com.android254.presentation.home.components.HomeCallForSpeakersLink(): kotlin.Unit
+public fun com.android254.presentation.home.components.HomeCallForSpeakersLink(modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.home.components.HomeEventPoster(): kotlin.Unit
+public fun com.android254.presentation.home.components.HomeEventPoster(modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.home.components.HomeHeaderSectionComponent(): kotlin.Unit
+public fun com.android254.presentation.home.components.HomeHeaderSectionComponent(modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.android254.presentation.home.components.HomeSectionHeaderComponent(sectionLabel: kotlin.String, sectionSize: kotlin.Int, onViewAllClicked: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
@@ -517,59 +537,66 @@ public fun com.android254.presentation.home.components.HomeSessionContent(sessio
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.home.components.HomeSessionLoadingComponent(): kotlin.Unit
-  skippable: true
-  restartable: true
-  params:
-
-@Composable
-public fun com.android254.presentation.home.components.HomeSessionLoadingItem(): kotlin.Unit
-  skippable: true
-  restartable: true
-  params:
-
-@Composable
-public fun com.android254.presentation.home.components.HomeSessionSection(modifier: androidx.compose.ui.Modifier, sessions: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionPresentationModel>, onSessionClick: kotlin.Function1<@[ParameterName(name = \, onViewAllSessionClicked: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.home.components.HomeSessionLoadingComponent(modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - modifier: STABLE (marked @Stable or @Immutable)
-    - sessions: STABLE (known stable type)
-    - onSessionClick: STABLE (function type)
-    - onViewAllSessionClicked: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.home.components.HomeSpacer(): kotlin.Unit
+public fun com.android254.presentation.home.components.HomeSessionLoadingItem(modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.home.components.HomeSpeakerComponent(speaker: com.android254.presentation.models.SpeakerUI, onClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.home.components.HomeSessionSection(sessions: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionPresentationModel>, onSessionClick: kotlin.Function1<@[ParameterName(name = \, modifier: androidx.compose.ui.Modifier, onViewAllSessionClicked: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - sessions: STABLE (known stable type)
+    - onSessionClick: STABLE (function type)
+    - modifier: STABLE (marked @Stable or @Immutable)
+    - onViewAllSessionClicked: STABLE (function type)
+
+@Composable
+public fun com.android254.presentation.home.components.HomeSpacer(modifier: androidx.compose.ui.Modifier): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - modifier: STABLE (marked @Stable or @Immutable)
+
+@Composable
+public fun com.android254.presentation.home.components.HomeSpeakerComponent(speaker: com.android254.presentation.models.SpeakerUI, modifier: androidx.compose.ui.Modifier, onClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - speaker: STABLE (class with no mutable properties)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - onClick: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.home.components.HomeSpeakersLoadingComponent(): kotlin.Unit
+public fun com.android254.presentation.home.components.HomeSpeakersLoadingComponent(modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.home.components.HomeSpeakersLoadingItem(): kotlin.Unit
+public fun com.android254.presentation.home.components.HomeSpeakersLoadingItem(modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.home.components.HomeSpeakersSection(speakers: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SpeakerUI>, navigateToSpeakers: kotlin.Function0<kotlin.Unit>, navigateToSpeaker: kotlin.Function1<kotlin.String, kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.home.components.HomeSpeakersSection(speakers: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SpeakerUI>, modifier: androidx.compose.ui.Modifier, navigateToSpeakers: kotlin.Function0<kotlin.Unit>, navigateToSpeaker: kotlin.Function1<kotlin.String, kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - speakers: STABLE (known stable type)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - navigateToSpeakers: STABLE (function type)
     - navigateToSpeaker: STABLE (function type)
 
@@ -611,7 +638,7 @@ private fun com.android254.presentation.home.screen.HomeScreen(viewState: com.an
     - onRefresh: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.sessionDetails.view.Body(paddingValues: androidx.compose.foundation.layout.PaddingValues, sessionDetails: com.android254.presentation.models.SessionDetailsPresentationModel, bookmarkSession: kotlin.Function1<kotlin.String, kotlin.Unit>, unBookmarkSession: kotlin.Function1<kotlin.String, kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.sessionDetails.view.Body(paddingValues: androidx.compose.foundation.layout.PaddingValues, sessionDetails: com.android254.presentation.models.SessionDetailsPresentationModel, bookmarkSession: kotlin.Function1<kotlin.String, kotlin.Unit>, unBookmarkSession: kotlin.Function1<kotlin.String, kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: false
   restartable: true
   params:
@@ -619,6 +646,7 @@ public fun com.android254.presentation.sessionDetails.view.Body(paddingValues: a
     - sessionDetails: RUNTIME (requires runtime check)
     - bookmarkSession: STABLE (function type)
     - unBookmarkSession: STABLE (function type)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.android254.presentation.sessionDetails.view.SessionDetailsRoute(viewModel: com.android254.presentation.sessionDetails.SessionDetailsViewModel, sessionId: kotlin.String, onNavigationIconClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
@@ -641,18 +669,20 @@ private fun com.android254.presentation.sessionDetails.view.SessionDetailsScreen
     - onNavigationIconClick: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.sessionDetails.view.components.SessionBannerImage(sessionDetails: com.android254.presentation.models.SessionDetailsPresentationModel): kotlin.Unit
+public fun com.android254.presentation.sessionDetails.view.components.SessionBannerImage(sessionDetails: com.android254.presentation.models.SessionDetailsPresentationModel, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: false
   restartable: true
   params:
     - sessionDetails: RUNTIME (requires runtime check)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.sessionDetails.view.components.SessionLevel(sessionLevel: kotlin.String): kotlin.Unit
+public fun com.android254.presentation.sessionDetails.view.components.SessionLevel(sessionLevel: kotlin.String, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - sessionLevel: STABLE (String is immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.android254.presentation.sessionDetails.view.components.SessionSpeakerNameAndFavouriteIcon(sessionDetails: com.android254.presentation.models.SessionDetailsPresentationModel, bookmarkSession: kotlin.Function1<kotlin.String, kotlin.Unit>, unBookmarkSession: kotlin.Function1<kotlin.String, kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
@@ -665,11 +695,12 @@ public fun com.android254.presentation.sessionDetails.view.components.SessionSpe
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.sessionDetails.view.components.SessionTimeAndRoom(sessionDetails: com.android254.presentation.models.SessionDetailsPresentationModel): kotlin.Unit
+public fun com.android254.presentation.sessionDetails.view.components.SessionTimeAndRoom(sessionDetails: com.android254.presentation.models.SessionDetailsPresentationModel, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: false
   restartable: true
   params:
     - sessionDetails: RUNTIME (requires runtime check)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.android254.presentation.sessionDetails.view.components.SessionTitleAndDescription(sessionDetails: com.android254.presentation.models.SessionDetailsPresentationModel, modifier: androidx.compose.ui.Modifier): kotlin.Unit
@@ -680,18 +711,20 @@ public fun com.android254.presentation.sessionDetails.view.components.SessionTit
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.sessionDetails.view.components.SpeakerTwitterHandle(speaker: com.android254.presentation.models.SessionDetailsSpeakerPresentationModel): kotlin.Unit
+public fun com.android254.presentation.sessionDetails.view.components.SpeakerTwitterHandle(speaker: com.android254.presentation.models.SessionDetailsSpeakerPresentationModel, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - speaker: STABLE (class with no mutable properties)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.sessionDetails.view.components.TopBar(onNavigationIconClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.sessionDetails.view.components.TopBar(onNavigationIconClick: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - onNavigationIconClick: STABLE (function type)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.android254.presentation.sessions.components.CurrentSessionComponent(session: com.android254.presentation.models.SessionPresentationModel, modifier: androidx.compose.ui.Modifier, onClicked: kotlin.Function1<kotlin.String, kotlin.Unit>): kotlin.Unit
@@ -703,28 +736,30 @@ public fun com.android254.presentation.sessions.components.CurrentSessionCompone
     - onClicked: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.sessions.components.CustomSwitch(width: androidx.compose.ui.unit.Dp, height: androidx.compose.ui.unit.Dp, iconInnerPadding: androidx.compose.ui.unit.Dp, thumbSize: androidx.compose.ui.unit.Dp, checked: kotlin.Boolean, onCheckedChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.sessions.components.CustomSwitch(checked: kotlin.Boolean, onCheckedChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, modifier: androidx.compose.ui.Modifier, width: androidx.compose.ui.unit.Dp, height: androidx.compose.ui.unit.Dp, iconInnerPadding: androidx.compose.ui.unit.Dp, thumbSize: androidx.compose.ui.unit.Dp): kotlin.Unit
   skippable: true
   restartable: true
   params:
+    - checked: STABLE (primitive type)
+    - onCheckedChange: STABLE (function type)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - width: STABLE (marked @Stable or @Immutable)
     - height: STABLE (marked @Stable or @Immutable)
     - iconInnerPadding: STABLE (marked @Stable or @Immutable)
     - thumbSize: STABLE (marked @Stable or @Immutable)
-    - checked: STABLE (primitive type)
-    - onCheckedChange: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.sessions.components.EventDaySelector(selectedDate: com.android254.presentation.models.EventDate, updateSelectedDay: kotlin.Function1<com.android254.presentation.models.EventDate, kotlin.Unit>, eventDates: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.EventDate>): kotlin.Unit
+public fun com.android254.presentation.sessions.components.EventDaySelector(selectedDate: com.android254.presentation.models.EventDate, updateSelectedDay: kotlin.Function1<com.android254.presentation.models.EventDate, kotlin.Unit>, eventDates: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.EventDate>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - selectedDate: STABLE (class with no mutable properties)
     - updateSelectedDay: STABLE (function type)
     - eventDates: STABLE (known stable type)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.sessions.components.EventDaySelectorButton(title: kotlin.String, subtitle: kotlin.String, selected: kotlin.Boolean, onClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.sessions.components.EventDaySelectorButton(title: kotlin.String, subtitle: kotlin.String, selected: kotlin.Boolean, onClick: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
@@ -732,9 +767,10 @@ public fun com.android254.presentation.sessions.components.EventDaySelectorButto
     - subtitle: STABLE (String is immutable)
     - selected: STABLE (primitive type)
     - onClick: STABLE (function type)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.sessions.components.SessionListComponent(isRefreshing: kotlin.Boolean, pullToRefreshState: androidx.compose.material3.pulltorefresh.PullToRefreshState, sessions: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionPresentationModel>, sessionScreenState: com.android254.presentation.sessions.view.SessionScreenState, isSessionLayoutList: kotlin.Boolean, navigateToSessionDetails: kotlin.Function1<@[ParameterName(name = \, onEvent: kotlin.Function1<com.android254.presentation.sessions.models.SessionsIntentHandler, kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.sessions.components.SessionListComponent(isRefreshing: kotlin.Boolean, pullToRefreshState: androidx.compose.material3.pulltorefresh.PullToRefreshState, sessions: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionPresentationModel>, sessionScreenState: com.android254.presentation.sessions.view.SessionScreenState, isSessionLayoutList: kotlin.Boolean, navigateToSessionDetails: kotlin.Function1<@[ParameterName(name = \, onEvent: kotlin.Function1<com.android254.presentation.sessions.models.SessionsIntentHandler, kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
@@ -745,33 +781,36 @@ public fun com.android254.presentation.sessions.components.SessionListComponent(
     - isSessionLayoutList: STABLE (primitive type)
     - navigateToSessionDetails: STABLE (function type)
     - onEvent: STABLE (function type)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.sessions.components.SessionLoadingComponent(): kotlin.Unit
+public fun com.android254.presentation.sessions.components.SessionLoadingComponent(modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.sessions.components.SessionsCardWithBannerImage(modifier: androidx.compose.ui.Modifier, session: com.android254.presentation.models.SessionPresentationModel, navigateToSessionDetails: kotlin.Function1<@[ParameterName(name = \, viewModel: com.android254.presentation.sessions.view.SessionsViewModel): kotlin.Unit
+public fun com.android254.presentation.sessions.components.SessionsCardWithBannerImage(session: com.android254.presentation.models.SessionPresentationModel, navigateToSessionDetails: kotlin.Function1<@[ParameterName(name = \, modifier: androidx.compose.ui.Modifier, viewModel: com.android254.presentation.sessions.view.SessionsViewModel): kotlin.Unit
   skippable: false
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - session: STABLE (class with no mutable properties)
     - navigateToSessionDetails: STABLE (function type)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - viewModel: RUNTIME (requires runtime check)
 
 @Composable
-public fun com.android254.presentation.sessions.components.SessionsErrorComponent(errorMessage: kotlin.String, retry: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.sessions.components.SessionsErrorComponent(errorMessage: kotlin.String, modifier: androidx.compose.ui.Modifier, retry: kotlin.Function0<kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - errorMessage: STABLE (String is immutable)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - retry: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.sessions.components.SessionsFilterPanel(onDismiss: kotlin.Function0<kotlin.Unit>, selectableFilters: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionsFilterOption>, currentSelections: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionsFilterOption>, updateSelectedFilterOptionList: kotlin.Function1<com.android254.presentation.models.SessionsFilterOption, kotlin.Unit>, clearSelectedFilterList: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.sessions.components.SessionsFilterPanel(onDismiss: kotlin.Function0<kotlin.Unit>, selectableFilters: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionsFilterOption>, currentSelections: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionsFilterOption>, updateSelectedFilterOptionList: kotlin.Function1<com.android254.presentation.models.SessionsFilterOption, kotlin.Unit>, clearSelectedFilterList: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
@@ -780,15 +819,17 @@ public fun com.android254.presentation.sessions.components.SessionsFilterPanel(o
     - currentSelections: STABLE (known stable type)
     - updateSelectedFilterOptionList: STABLE (function type)
     - clearSelectedFilterList: STABLE (function type)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.sessions.components.SessionsLoadingCard(): kotlin.Unit
+public fun com.android254.presentation.sessions.components.SessionsLoadingCard(modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.sessions.components.SessionsStateComponent(sessionsUiState: com.android254.presentation.sessions.models.SessionsUiState, navigateToSessionDetails: kotlin.Function1<@[ParameterName(name = \, isRefreshing: kotlin.Boolean, sessionScreenState: com.android254.presentation.sessions.view.SessionScreenState, isSessionLayoutList: kotlin.Boolean, onEvent: kotlin.Function1<com.android254.presentation.sessions.models.SessionsIntentHandler, kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.sessions.components.SessionsStateComponent(sessionsUiState: com.android254.presentation.sessions.models.SessionsUiState, navigateToSessionDetails: kotlin.Function1<@[ParameterName(name = \, isRefreshing: kotlin.Boolean, sessionScreenState: com.android254.presentation.sessions.view.SessionScreenState, isSessionLayoutList: kotlin.Boolean, onEvent: kotlin.Function1<com.android254.presentation.sessions.models.SessionsIntentHandler, kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
@@ -798,15 +839,17 @@ public fun com.android254.presentation.sessions.components.SessionsStateComponen
     - sessionScreenState: STABLE (class with no mutable properties)
     - isSessionLayoutList: STABLE (primitive type)
     - onEvent: STABLE (function type)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.sessions.components.SpeakerDetailsAndLikeButtonComponent(onBookmarkClicked: kotlin.Function0<kotlin.Unit>, isSessionStarred: kotlin.Boolean, speakers: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionSpeakersPresentationModel>): kotlin.Unit
+public fun com.android254.presentation.sessions.components.SpeakerDetailsAndLikeButtonComponent(onBookmarkClicked: kotlin.Function0<kotlin.Unit>, isSessionStarred: kotlin.Boolean, speakers: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionSpeakersPresentationModel>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - onBookmarkClicked: STABLE (function type)
     - isSessionStarred: STABLE (primitive type)
     - speakers: STABLE (known stable type)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
 private fun com.android254.presentation.sessions.components.animateAlignmentAsState(targetBiasValue: kotlin.Float): androidx.compose.runtime.State<androidx.compose.ui.BiasAlignment>
@@ -824,7 +867,7 @@ public fun com.android254.presentation.sessions.view.SessionsRoute(sessionsViewM
     - navigateToSessionDetails: STABLE (function type)
 
 @Composable
-public fun com.android254.presentation.sessions.view.SessionsScreen(sessionsUiState: com.android254.presentation.sessions.models.SessionsUiState, selectedEventDate: com.android254.presentation.models.EventDate, isRefreshing: kotlin.Boolean, currentSelections: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionsFilterOption>, navigateToSessionDetails: kotlin.Function1<@[ParameterName(name = \, onEvent: kotlin.Function1<com.android254.presentation.sessions.models.SessionsIntentHandler, kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.sessions.view.SessionsScreen(sessionsUiState: com.android254.presentation.sessions.models.SessionsUiState, selectedEventDate: com.android254.presentation.models.EventDate, isRefreshing: kotlin.Boolean, currentSelections: kotlinx.collections.immutable.ImmutableList<com.android254.presentation.models.SessionsFilterOption>, navigateToSessionDetails: kotlin.Function1<@[ParameterName(name = \, onEvent: kotlin.Function1<com.android254.presentation.sessions.models.SessionsIntentHandler, kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
@@ -834,14 +877,15 @@ public fun com.android254.presentation.sessions.view.SessionsScreen(sessionsUiSt
     - currentSelections: STABLE (known stable type)
     - navigateToSessionDetails: STABLE (function type)
     - onEvent: STABLE (function type)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.android254.presentation.speakers.view.SpeakerComponent(modifier: androidx.compose.ui.Modifier, speaker: com.android254.presentation.models.SpeakerUI, onClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+public fun com.android254.presentation.speakers.view.SpeakerComponent(speaker: com.android254.presentation.models.SpeakerUI, modifier: androidx.compose.ui.Modifier, onClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - speaker: STABLE (class with no mutable properties)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - onClick: STABLE (function type)
 
 @Composable


### PR DESCRIPTION
Clears the remaining backlog: edge-to-edge, the four open Compose lint rules, and the deprecated network helper. **Lint is now at zero across the whole module graph** — every Compose rule is `error`.

### Edge-to-edge (plan §1 / §3.4)
`targetSdk` 37 means edge-to-edge is enforced, and the app had no insets handling at all — what looked right was the framework's compatibility path plus a `statusBarColor` write that has been a no-op since API 35. `MainActivity` opts in; the outer Scaffold consumes its insets so the eight nested per-screen Scaffolds don't apply them twice. `ChaiTheme` loses its whole `SideEffect` and is now purely declarative, which also closes **B5** (it behaves the same in previews, Robolectric and the app). `android:statusBarColor` removed from both themes.

### Compose lint: 144 warnings → 0
- **ComposePreviewPublic (42)** — previews are private; six of them were in chai's published API.
- **ComposeUnstableCollections (20)** — state holders expose `ImmutableList`, so immutability flows from ViewModel to composable. Measured: **skippable composables 54/101 → 76/101, RUNTIME params 48 → 19.**
- **ComposeParameterOrder (34)** — `modifier` moved to its documented slot. All call sites used named args.
- **ComposeModifierMissing (48)** — each composable takes and forwards a `modifier`.

### safeApiCall
Deleted. `AuthApi` and `SessionsApi` return `DataResult` like every other API; `AuthManager` maps a result instead of catching and re-classifying exceptions, so the `networkError` flag is the one the network layer determined. `RemoteSessionsDataSourceImpl` no longer declares a `DataResult` return while letting exceptions escape past it.

### Session time and venue rendering
Found by running the app. The sessions list wrapped mid-word — `08:0 / 0 / AM` and `SAPP / HIRE, / OPAL` — because the time gutter was `weight(0.2f)`, too narrow for `08:00`, and time and venue shared a Row with no room for both. The gutter now sizes to its content and the venue sits under the time. Session details showed `08:00 - 09:30:00`: the details mapper passed the raw `endTime` through while the list mapper formatted it. Both now use `getTimePeriod` and take the venue from `roomList`, so rooms read `SAPPHIRE, OPAL`.

These two were pre-existing, not introduced here — screenshots of both screens on `main` are identical.

### Worth a reviewer's attention
Threading a modifier is the one thing a compiler can't check — the wrong node compiles fine and lays out wrong. I audited where each landed; **six were wrong and are fixed** (a data class, a `BorderStroke`, two child `Spacer`s, and `SessionsCard`/`SessionDetails` roots dropping the caller's modifier entirely).

Also checked rather than assumed: fake preview data does **not** ship — `FakeSessions` is absent from the release `mapping.txt` while controls appear hundreds of times. It stays in `src/main` because `@Preview` and `SessionStateProvider` consume it.

Verified: `spotlessCheck ktlintCheck detekt lint test assembleDebug assembleRelease stabilityCheck`, plus a run on a physical device (OPPO CPH2113, API 31). Every screen was screenshotted against the same build of `main`: the only differences are the two fixes above and the OS navigation bar's own anti-aliasing.
